### PR TITLE
Fix false positives for ignored mismatches.

### DIFF
--- a/lib/scientist/result.rb
+++ b/lib/scientist/result.rb
@@ -47,7 +47,7 @@ class Scientist::Result
 
   # Public: was the result a match between all behaviors?
   def matched?
-    mismatched.empty?
+    mismatched.empty? && !ignored?
   end
 
   # Public: were there mismatches in the behaviors?

--- a/test/scientist/result_test.rb
+++ b/test/scientist/result_test.rb
@@ -70,6 +70,7 @@ describe Scientist::Result do
     result = Scientist::Result.new @experiment, observations: [x, y], control: x
 
     refute result.mismatched?
+    refute result.matched?
     assert result.ignored?
     assert_equal [], result.mismatched
     assert_equal [y], result.ignored


### PR DESCRIPTION
`Result#matched?` returns `true` when it was actually an ignored mismatch.

In the publishing example in the README, for instance:

``` ruby
class MyExperiment
  def publish(result)
    # Store the timing for the control value,
    $statsd.timing "science.#{name}.control", result.control.duration
    # for the candidate (only the first, see "Breaking the rules" below,
    $statsd.timing "science.#{name}.candidate", result.candidates.first.duration

    # and counts for match/ignore/mismatch:
    if result.matched?
      $statsd.increment "science.#{name}.matched"
    elsif result.ignored?
      $statsd.increment "science.#{name}.ignored"
    else
      $statsd.increment "science.#{name}.mismatched"
      # Finally, store mismatches in redis so they can be retrieved and examined
      # later on, for debugging and research.
      store_mismatch_data(result)
    end
  end
```

Given this experiment:

``` ruby
science "test" do |e|
  e.ignore { true }
  e.use { true }
  e.try { false }
end
```

The `publish` method will increment the counter for `science.test.matched` rather than incrementing `science.test.ignored`.
