### PR TITLE
Bump to version 0.0.2

### DIFF
--- a/lib/scientist/version.rb
+++ b/lib/scientist/version.rb
@@ -1,3 +1,3 @@
 module Scientist
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Release a new version including the changes in https://github.com/github/scientist/pull/7 to remove the dependency on ruby >= 2.1 and a buxfix in https://github.com/github/scientist/pull/8.

cc @zerowidth @jbarnette @calavera @eric
