### PR TITLE
Re-raise candidate exceptions when raise_on_mismatches? is true

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -181,8 +181,12 @@ module Scientist::Experiment
       raise control.exception
     end
 
-    if self.class.raise_on_mismatches? && result.mismatched?
-      raise MismatchError.new(name, result)
+    if self.class.raise_on_mismatches?
+      if raised = observations.detect { |o| o.raised? }
+        raise raised.exception
+      elsif result.mismatched?
+        raise MismatchError.new(name, result)
+      end
     end
 
     control.value

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -394,5 +394,13 @@ describe Scientist::Experiment do
 
       @ex.run
     end
+
+    it "reraises candidate exceptions if raise on mismatches is enabled" do
+      Fake.raise_on_mismatches = true
+      @ex.use { "fine" }
+      @ex.try { raise "not fine" }
+
+      assert_raises(RuntimeError, "not fine") { @ex.run }
+    end
   end
 end


### PR DESCRIPTION
When writing a candidate codepath it's common to make silly mistakes/typos that generate exceptions. In tests it would be nice to see these exceptions printed straight to the console. Currently you only get to see the exception buried inside a MismatchError message, like:

    ...lots of other text... @exception=#<ArgumentError: wrong number of arguments (0 for 1..2)>

There's no backtrace, which makes it hard to track down what went wrong.

Now, when `raise_on_mismatches?` is true, we'll re-raise any candidate exceptions we can find. This lets you see the full exception and backtrace in the test output.