### PR TITLE
Add Experiment#before_run

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,9 @@ The `widget-permissions` and `widget-destruction` experiments will both have a `
 
 ### Expensive setup
 
-If an experiment requires expensive setup that should only run when the experiment is going to be run, use the `before_run` method.
+If an experiment requires expensive setup that should only occur when the experiment is going to be run, define it with the `before_run` method:
 
 ```ruby
-
 # Code under test modifies this in-place. We want to copy it for the
 # candidate code, but only when needed:
 value_for_original_code = big_object

--- a/README.md
+++ b/README.md
@@ -144,6 +144,26 @@ end
 
 The `widget-permissions` and `widget-destruction` experiments will both have a `:widget` key in their contexts.
 
+### Expensive setup
+
+If an experiment requires expensive setup that should only run when the experiment is going to be run, use the `before_run` method.
+
+```ruby
+
+# Code under test modifies this in-place. We want to copy it for the
+# candidate code, but only when needed:
+value_for_original_code = big_object
+value_for_new_code      = nil
+
+science "expensive-but-worthwhile" do |e|
+  e.before_run do
+    value_for_new_code = big_object.deep_copy
+  end
+  e.use { original_code(value_for_original_code) }
+  e.try { new_code(value_for_new_code) }
+end
+```
+
 ### Keeping it clean
 
 Sometimes you don't want to store the full value for later analysis. For example, an experiment may return `User` instances, but when researching a mismatch, all you care about is the logins. You can define how to clean these values in an experiment:

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -42,6 +42,16 @@ module Scientist::Experiment
     base.extend RaiseOnMismatch
   end
 
+  # Define a block of code to run before an experiment begins, if the experiment
+  # is enabled.
+  #
+  # The block takes no arguments.
+  #
+  # Returns the configured block.
+  def before_run(&block)
+    @_scientist_before_run = block
+  end
+
   # A Hash of behavior blocks, keyed by String name. Register behavior blocks
   # with the `try` and `use` methods.
   def behaviors
@@ -158,7 +168,13 @@ module Scientist::Experiment
       raise Scientist::BehaviorMissing.new(self, name)
     end
 
-    return block.call unless should_experiment_run?
+    unless should_experiment_run?
+      return block.call
+    end
+
+    if @_scientist_before_run
+      @_scientist_before_run.call
+    end
 
     observations = []
 

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -395,4 +395,34 @@ describe Scientist::Experiment do
       @ex.run
     end
   end
+
+  describe "before run block" do
+    it "runs when an experiment is enabled" do
+      control_ok = candidate_ok = false
+      before = false
+      @ex.before_run { before = true }
+      @ex.use { control_ok = before }
+      @ex.try { candidate_ok = before }
+
+      @ex.run
+
+      assert before, "before_run should have run"
+      assert control_ok, "control should have run after before_run"
+      assert candidate_ok, "candidate should have run after before_run"
+    end
+
+    it "does not run when an experiment is disabled" do
+      before = false
+
+      def @ex.enabled?
+        false
+      end
+      @ex.before_run { before = true }
+      @ex.use { "value" }
+      @ex.try { "value" }
+      @ex.run
+
+      refute before, "before_run should not have run"
+    end
+  end
 end


### PR DESCRIPTION
This configurable block will allow custom behavior to run before an experiment begins. This lets a programmer run expensive setup code (e.g. difficult-to-calculate context data or duplication of large objects) before, and only when, an experiment runs.

cc @aroben 

- [x] code
- [x] README update