### PR TITLE
Better mismatch errors

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -15,8 +15,33 @@ module Scientist::Experiment
 
   # A mismatch, raised when raise_on_mismatches is enabled.
   class MismatchError < StandardError
+    attr_reader :name, :result
+
     def initialize(name, result)
-      super "#{name}: control #{result.control.inspect}, candidates #{result.candidates.map(&:inspect)}"
+      @name   = name
+      @result = result
+      super "experiment '#{name}' observations mismatched"
+    end
+
+    # The default formatting is nearly unreadable, so make it useful.
+    #
+    # The assumption here is that errors raised in a test environment are
+    # printed out as strings, rather than using #inspect.
+    def to_s
+      super + ":\n" +
+      format_observation(result.control) + "\n" +
+      result.candidates.map { |candidate| format_observation(candidate) }.join("\n") +
+      "\n"
+    end
+
+    def format_observation(observation)
+      observation.name + ":\n" +
+      if observation.raised?
+        observation.exception.inspect.prepend("  ") + "\n" +
+          observation.exception.backtrace.map { |line| line.prepend("    ") }.join("\n")
+      else
+        observation.value.inspect.prepend("  ")
+      end
     end
   end
 
@@ -194,7 +219,7 @@ module Scientist::Experiment
     end
 
     if self.class.raise_on_mismatches? && result.mismatched?
-      raise MismatchError.new(name, result)
+      raise MismatchError.new(self.name, result)
     end
 
     if control.raised?

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -193,15 +193,15 @@ module Scientist::Experiment
       raised :publish, ex
     end
 
-    if control.raised?
-      raise control.exception
-    end
-
     if self.class.raise_on_mismatches? && result.mismatched?
       raise MismatchError.new(name, result)
     end
 
-    control.value
+    if control.raised?
+      raise control.exception
+    else
+      control.value
+    end
   end
 
   # Define a block that determines whether or not the experiment should run.

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -392,7 +392,21 @@ describe Scientist::Experiment do
       @ex.use { "fine" }
       @ex.try { "not fine" }
 
-      @ex.run
+      assert_equal "fine", @ex.run
+    end
+
+    it "raises a mismatch error if the control raises and candidate doesn't" do
+      Fake.raise_on_mismatches = true
+      @ex.use { raise "control" }
+      @ex.try { "candidate" }
+      assert_raises(Scientist::Experiment::MismatchError) { @ex.run }
+    end
+
+    it "raises a mismatch error if the candidate raises and the control doesn't" do
+      Fake.raise_on_mismatches = true
+      @ex.use { "control" }
+      @ex.try { raise "candidate" }
+      assert_raises(Scientist::Experiment::MismatchError) { @ex.run }
     end
   end
 

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -408,6 +408,66 @@ describe Scientist::Experiment do
       @ex.try { raise "candidate" }
       assert_raises(Scientist::Experiment::MismatchError) { @ex.run }
     end
+
+    describe "MismatchError" do
+      before do
+        Fake.raise_on_mismatches = true
+        @ex.use { :foo }
+        @ex.try { :bar }
+        begin
+          @ex.run
+        rescue Scientist::Experiment::MismatchError => e
+          @mismatch = e
+        end
+        assert @mismatch
+      end
+
+      it "has the name of the experiment" do
+        assert_equal @ex.name, @mismatch.name
+      end
+
+      it "includes the experiments' results" do
+        assert_equal @ex.published_result, @mismatch.result
+      end
+
+      it "formats nicely as a string" do
+        assert_equal <<-STR, @mismatch.to_s
+experiment 'experiment' observations mismatched:
+control:
+  :foo
+candidate:
+  :bar
+        STR
+      end
+
+      it "includes the backtrace when an observation raises" do
+        mismatch = nil
+        ex = Fake.new
+        ex.use { "value" }
+        ex.try { raise "error" }
+
+        begin
+          ex.run
+        rescue Scientist::Experiment::MismatchError => e
+          mismatch = e
+        end
+
+        # Should look like this:
+        # experiment 'experiment' observations mismatched:
+        # control:
+        #   "value"
+        # candidate:
+        #   #<RuntimeError: error>
+        #     test/scientist/experiment_test.rb:447:in `block (5 levels) in <top (required)>'
+        # ... (more backtrace)
+        lines = mismatch.to_s.split("\n")
+        assert_equal "control:", lines[1]
+        assert_equal "  \"value\"", lines[2]
+        assert_equal "candidate:", lines[3]
+        assert_equal "  #<RuntimeError: error>", lines[4]
+        assert_match %r(    test/scientist/experiment_test.rb:\d+:in `block), lines[5]
+      end
+    end
   end
 
   describe "before run block" do


### PR DESCRIPTION
This PR makes MismatchErrors more useful:

* Always raise a MismatchError, regardless of whether or not it's the control path that raised. This clarifies the situation discussed here: https://github.com/github/scientist/pull/16#issuecomment-74751771
* Add name/results accessors to MismatchError so the raw information can be extracted if desired.
* Add a pretty format for the console so the errors are more useful.

The pretty format looks something like this:

```
Scientist::Experiment::MismatchError: experiment 'experiment' observations mismatched:
control:
  :foo
candidate:
  :bar
```

When something raises:

```
Scientist::Experiment::MismatchError: experiment 'experiment' observations mismatched:
control:
  \"value\"
candidate:
  #<RuntimeError: error>
    test/scientist/experiment_test.rb:447:in `block (5 levels) in <top (required)>'
    scientist/lib/scientist/observation.rb:28:in `call'
    scientist/lib/scientist/observation.rb:28:in `initialize'
    scientist/lib/scientist/experiment.rb:210:in `new'
    scientist/lib/scientist/experiment.rb:210:in `block in run'
    scientist/lib/scientist/experiment.rb:208:in `each'
    [...]
```

And it even works with named candidates:

```
Scientist::Experiment::MismatchError: experiment 'who-is-spartacus' observations mismatched:
spartacus:
  "i am spartacus"
carl:
  "no, i am spartacus"
```

It's normally considered bad practice to override `to_s` like this, but since `MismatchError` is designed specifically for console or console-like test environments rather than a live production system, I'm placing utility over good ruby style. It's more helpful to see all the information–including backtraces, if an observation raised an exception–than a large incomprehensible blob of text, which is what this looked like before.

@aroben I think this obviates #16 for your "I need to debug this" use case.