### PR TITLE
Allow setting raise_on_mismatches per Experiment instance

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -275,7 +275,7 @@ module Scientist::Experiment
 
   # Whether or not to raise a mismatch error when a mismatch occurs.
   def raise_on_mismatches?
-    if @raise_on_mismatches.nil?
+    if raise_on_mismatches.nil?
       self.class.raise_on_mismatches?
     else
       !!raise_on_mismatches

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -6,6 +6,7 @@
 module Scientist::Experiment
 
   # Whether to raise when the control and candidate mismatch.
+  # If this is nil, raise_on_mismatches class attribute is used instead.
   attr_accessor :raise_on_mismatches
 
   # Create a new instance of a class that implements the Scientist::Experiment

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -218,7 +218,7 @@ module Scientist::Experiment
       raised :publish, ex
     end
 
-    if self.class.raise_on_mismatches? && result.mismatched?
+    if raise_on_mismatches? && result.mismatched?
       raise MismatchError.new(self.name, result)
     end
 
@@ -268,5 +268,17 @@ module Scientist::Experiment
   # Register the control behavior for this experiment.
   def use(&block)
     try "control", &block
+  end
+
+  def raise_on_mismatches=(bool)
+    @raise_on_mismatches = bool
+  end
+
+  def raise_on_mismatches?
+    if @raise_on_mismatches.nil?
+      self.class.raise_on_mismatches?
+    else
+      @raise_on_mismatches
+    end
   end
 end

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -5,6 +5,9 @@
 # implements Scientist::Experiment's interface.
 module Scientist::Experiment
 
+  # Whether to raise when the control and candidate mismatch.
+  attr_accessor :raise_on_mismatches
+
   # Create a new instance of a class that implements the Scientist::Experiment
   # interface.
   #
@@ -270,15 +273,12 @@ module Scientist::Experiment
     try "control", &block
   end
 
-  def raise_on_mismatches=(bool)
-    @raise_on_mismatches = bool
-  end
-
+  # Whether or not to raise a mismatch error when a mismatch occurs.
   def raise_on_mismatches?
     if @raise_on_mismatches.nil?
       self.class.raise_on_mismatches?
     else
-      @raise_on_mismatches
+      !!raise_on_mismatches
     end
   end
 end

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -409,6 +409,26 @@ describe Scientist::Experiment do
       assert_raises(Scientist::Experiment::MismatchError) { @ex.run }
     end
 
+    describe "#raise_on_mismatches?" do
+      it "raises when there is a mismatch if the experiment instance's raise on mismatches is enabled" do
+        Fake.raise_on_mismatches = false
+        @ex.raise_on_mismatches = true
+        @ex.use { "fine" }
+        @ex.try { "not fine" }
+
+        assert_raises(Scientist::Experiment::MismatchError) { @ex.run }
+      end
+
+      it "doesn't raise when there is a mismatch if the experiment instance's raise on mismatches is disabled" do
+        Fake.raise_on_mismatches = true
+        @ex.raise_on_mismatches = false
+        @ex.use { "fine" }
+        @ex.try { "not fine" }
+
+        assert_equal "fine", @ex.run
+      end
+    end
+
     describe "MismatchError" do
       before do
         Fake.raise_on_mismatches = true

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -427,6 +427,18 @@ describe Scientist::Experiment do
 
         assert_equal "fine", @ex.run
       end
+
+      it "respects the raise_on_mismatches class attribute by default" do
+        Fake.raise_on_mismatches = false
+        @ex.use { "fine" }
+        @ex.try { "not fine" }
+
+        assert_equal "fine", @ex.run
+
+        Fake.raise_on_mismatches = true
+
+        assert_raises(Scientist::Experiment::MismatchError) { @ex.run }
+      end
     end
 
     describe "MismatchError" do


### PR DESCRIPTION
This patch addresses #21. I also find this would be useful, so here's the patch.