### PR TITLE
Fixing builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ script: script/test
 rvm:
   - 1.9.3
   - 2.1.5
+before_install: gem install bundler


### PR DESCRIPTION
Currently certain gems cannot be installed when Travis is running the build on Ruby 1.9.3. With this PR, `bundler` is installed before the gems are installed.