### PR TITLE
Bump CI Ruby patchlevels, add Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ cache: bundler
 script: script/test
 rvm:
   - 1.9.3
-  - 2.1.5
+  - 2.0.0
+  - 2.1.8
+  - 2.2.4
 before_install: gem install bundler


### PR DESCRIPTION
This gets us up-to-date with green builds on Ruby 1.9, 2.0, 2.1, and 2.2. Fixes https://github.com/github/scientist/pull/24.

/cc https://github.com/github/scientist/pull/26