### PR TITLE
Added Coveralls for code coverage tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.bundle
 /.ruby-version
 /Gemfile.lock
+/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ rvm:
   - 2.1.8
   - 2.2.4
 before_install: gem install bundler
+addons:
+ apt:
+   packages:
+     - libgmp-dev

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scientist!
 
-A Ruby library for carefully refactoring critical paths. [![Build Status](https://travis-ci.org/github/scientist.svg?branch=master)](https://travis-ci.org/github/scientist)
+A Ruby library for carefully refactoring critical paths. [![Build Status](https://travis-ci.org/github/scientist.svg?branch=master)](https://travis-ci.org/github/scientist) [![Coverage Status](https://coveralls.io/repos/github/github/scientist/badge.svg?branch=master)](https://coveralls.io/github/github/scientist?branch=master)
 
 ## How do I science?
 

--- a/scientist.gemspec
+++ b/scientist.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "minitest", "~> 5.8"
+  gem.add_development_dependency "coveralls", "~> 0.8"
 end

--- a/script/test
+++ b/script/test
@@ -6,6 +6,7 @@ set -e
 cd $(dirname "$0")/..
   script/bootstrap && ruby -I lib \
     -e 'require "bundler/setup"' \
+    -e 'require "coveralls"; Coveralls.wear!{ add_filter ".bundle" }' \
     -e 'require "minitest/autorun"' \
     -e 'require "scientist"' \
     -e '(ARGV.empty? ? Dir["test/**/*_test.rb"] : ARGV).each { |f| load f }' -- "$@"


### PR DESCRIPTION
Here's the shiny new badge added to the README:

![screen shot 2016-02-05 at 11 13 04 am](https://cloud.githubusercontent.com/assets/1129/12856376/79f765cc-cbf9-11e5-8102-a131d0e7e80c.png)

And the coverage tracking:

![screen shot 2016-02-05 at 11 08 40 am](https://cloud.githubusercontent.com/assets/1129/12856261/e4846062-cbf8-11e5-98de-70d03b0b08c3.png)

Currently [here](https://coveralls.io/github/nickmerwin/scientist) but we'll move it to the proper repo url after merging.

Thanks!
