### PR TITLE
Add alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,15 +435,23 @@ end
 
 Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs the unit tests. All development dependencies are installed automatically. Science requires Ruby 1.9 or newer.
 
+## Alternatives
+
+- [daylerees/scientist](https://github.com/daylerees/scientist) (PHP)
+- [haacked/scientist.net](https://github.com/haacked/scientist.net) (.NET)
+- [joealcorn/laboratory](https://github.com/joealcorn/laboratory) (Python)
+- [MadcapJake/Test-Lab](https://github.com/MadcapJake/Test-Lab) (Perl 6)
+- [rawls238/Scientist4J](https://github.com/rawls238/Scientist4J) (Java)
+- [tomiaijo/scientist](https://github.com/tomiaijo/scientist) (C++)
+- [trello/scientist](https://github.com/trello/scientist) (node.js)
+- [yeller/laboratory](https://github.com/yeller/laboratory) (Clojure)
+- [lancew/Scientist](https://github.com/lancew/Scientist) (Perl 5)
+- [lancew/ScientistP6](https://github.com/lancew/ScientistP6) (Perl 6)
+- [ziyasal/scientist.js](https://github.com/ziyasal/scientist.js) (node.js, ES6)
+
 ## Maintainers
 
 [@jbarnette](https://github.com/jbarnette),
 [@jesseplusplus](https://github.com/jesseplusplus),
 [@rick](https://github.com/rick),
 and [@zerowidth](https://github.com/zerowidth)
-
-## Alternatives
-
-Here are other implementations of Scientist available in different languages.
-
-- [daylerees/scientist](https://github.com/daylerees/scientist) for [PHP](http://php.net/) by [Dayle Rees](https://github.com/daylerees).

--- a/README.md
+++ b/README.md
@@ -440,14 +440,15 @@ Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs t
 - [daylerees/scientist](https://github.com/daylerees/scientist) (PHP)
 - [haacked/scientist.net](https://github.com/haacked/scientist.net) (.NET)
 - [joealcorn/laboratory](https://github.com/joealcorn/laboratory) (Python)
-- [MadcapJake/Test-Lab](https://github.com/MadcapJake/Test-Lab) (Perl 6)
 - [rawls238/Scientist4J](https://github.com/rawls238/Scientist4J) (Java)
 - [tomiaijo/scientist](https://github.com/tomiaijo/scientist) (C++)
 - [trello/scientist](https://github.com/trello/scientist) (node.js)
+- [ziyasal/scientist.js](https://github.com/ziyasal/scientist.js) (node.js, ES6)
 - [yeller/laboratory](https://github.com/yeller/laboratory) (Clojure)
 - [lancew/Scientist](https://github.com/lancew/Scientist) (Perl 5)
 - [lancew/ScientistP6](https://github.com/lancew/ScientistP6) (Perl 6)
-- [ziyasal/scientist.js](https://github.com/ziyasal/scientist.js) (node.js, ES6)
+- [MadcapJake/Test-Lab](https://github.com/MadcapJake/Test-Lab) (Perl 6)
+
 
 ## Maintainers
 


### PR DESCRIPTION
This tidies up the "Alternatives" section a bit and adds the projects mentioned in @daylerees' https://github.com/github/scientist/pull/35.

@jesseplusplus @rick @zerowidth I haven't audited these for licenses or completeness at all, any concern? I'll take a quick look before this ships.

/cc @Haacked @joealcorn @MadcapJake @rawls238 @tomiaijo @tcrayford @ziyasal @lancew