### PR TITLE
Update .NET alternative link to match github org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs t
 ## Alternatives
 
 - [daylerees/scientist](https://github.com/daylerees/scientist) (PHP)
-- [haacked/scientist.net](https://github.com/haacked/scientist.net) (.NET)
+- [github/scientist.net](https://github.com/github/scientist.net) (.NET)
 - [joealcorn/laboratory](https://github.com/joealcorn/laboratory) (Python)
 - [rawls238/Scientist4J](https://github.com/rawls238/Scientist4J) (Java)
 - [tomiaijo/scientist](https://github.com/tomiaijo/scientist) (C++)


### PR DESCRIPTION
The .NET port of Scientist [was just moved][] to the github organization.  This is just a minor change to adjust the URL in the README.

[was just moved]: http://haacked.com/archive/2016/09/29/scientist-1.0-released/