### PR TITLE
Accept false boolean results

### DIFF
--- a/lib/scientist/observation.rb
+++ b/lib/scientist/observation.rb
@@ -38,9 +38,7 @@ class Scientist::Observation
   # Return a cleaned value suitable for publishing. Uses the experiment's
   # defined cleaner block to clean the observed value.
   def cleaned_value
-    if value
-      experiment.clean_value value
-    end
+    experiment.clean_value value unless value.nil?
   end
 
   # Is this observation equivalent to another?

--- a/test/scientist/observation_test.rb
+++ b/test/scientist/observation_test.rb
@@ -95,6 +95,11 @@ describe Scientist::Observation do
       assert_nil a.cleaned_value
     end
 
+    it "returns false boolean values" do
+      a = Scientist::Observation.new("test", @experiment) { false }
+      assert_equal false, a.cleaned_value
+    end
+
     it "cleans false values" do
       @experiment.clean { |value| value.to_s.upcase }
       a = Scientist::Observation.new("test", @experiment) { false }

--- a/test/scientist/observation_test.rb
+++ b/test/scientist/observation_test.rb
@@ -88,6 +88,18 @@ describe Scientist::Observation do
       a = Scientist::Observation.new("test", @experiment) { "test" }
       assert_equal "TEST", a.cleaned_value
     end
+
+    it "doesn't clean nil values" do
+      @experiment.clean { |value| "foo" }
+      a = Scientist::Observation.new("test", @experiment) { nil }
+      assert_nil a.cleaned_value
+    end
+
+    it "cleans false values" do
+      @experiment.clean { |value| value.to_s.upcase }
+      a = Scientist::Observation.new("test", @experiment) { false }
+      assert_equal "FALSE", a.cleaned_value
+    end
   end
 
 end


### PR DESCRIPTION
I found for experiments that have simple `true` or `false` boolean results, `false` was getting reported as `nil`. This PR updates Observation to pass `false` boolean values to the cleaner.