### PR TITLE
Don't rescue signals when running experiments

### DIFF
--- a/lib/scientist/observation.rb
+++ b/lib/scientist/observation.rb
@@ -26,7 +26,7 @@ class Scientist::Observation
 
     begin
       @value = block.call
-    rescue Object => e
+    rescue StandardError => e
       @exception = e
     end
 


### PR DESCRIPTION
`rescue Object` is equivalent to `rescue Exception`, which will catch signals and other messages which shouldn't be silenced during an experiment.

See https://github.com/github/scientist/issues/60