### PR TITLE
Remove circular reference from initializer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ class MyExperiment
 
   attr_accessor :name
 
-  def initialize(name: name)
+  def initialize(name:)
     @name = name
   end
 
@@ -254,7 +254,7 @@ class MyExperiment
 
   attr_accessor :name, :percent_enabled
 
-  def initialize(name: name)
+  def initialize(name:)
     @name = name
     @percent_enabled = 100
   end


### PR DESCRIPTION
Running the code as-is from README outputs a warning:

`warning: circular argument reference - name`