### PR TITLE
Move rescued types to a constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,18 @@ Scientist will raise a `Scientist::Experiment::MismatchError` exception if any o
 
 ### Handling errors
 
-If an exception is raised within any of scientist's internal helpers, like `publish`, `compare`, or `clean`, the `raised` method is called with the symbol name of the internal operation that failed and the exception that was raised. The default behavior of `Scientist::Default` is to simply re-raise the exception. Since this halts the experiment entirely, it's often a better idea to handle this error and continue so the experiment as a whole isn't canceled entirely:
+#### In candidate code
+
+Scientist rescues and tracks _all_ exceptions raised in a `try` or `use` block, including some where rescuing may cause unexpected behavior (like `SystemExit` or `ScriptError`). To rescue a more restrictive set of exceptions, modify the `RESCUES` list:
+
+```ruby
+# default is [Exception]
+Scientist::Observation::RESCUES.replace [StandardError]
+```
+
+#### In a Scientist callback
+
+If an exception is raised within any of Scientist's internal helpers, like `publish`, `compare`, or `clean`, the `raised` method is called with the symbol name of the internal operation that failed and the exception that was raised. The default behavior of `Scientist::Default` is to simply re-raise the exception. Since this halts the experiment entirely, it's often a better idea to handle this error and continue so the experiment as a whole isn't canceled entirely:
 
 ```ruby
 class MyExperiment

--- a/lib/scientist/observation.rb
+++ b/lib/scientist/observation.rb
@@ -1,6 +1,10 @@
 # What happened when this named behavior was executed? Immutable.
 class Scientist::Observation
 
+  # An Array of Exception types to rescue when initializing an observation.
+  # NOTE: This Array will change to `[StandardError]` in the next major release.
+  RESCUES = [Exception]
+
   # The experiment this observation is for
   attr_reader :experiment
 
@@ -26,7 +30,7 @@ class Scientist::Observation
 
     begin
       @value = block.call
-    rescue Object => e
+    rescue *RESCUES => e
       @exception = e
     end
 

--- a/test/scientist/observation_test.rb
+++ b/test/scientist/observation_test.rb
@@ -25,6 +25,37 @@ describe Scientist::Observation do
     assert_nil ob.value
   end
 
+  describe "::RESCUES" do
+    before do
+      @original = Scientist::Observation::RESCUES.dup
+    end
+
+    after do
+      Scientist::Observation::RESCUES.replace(@original)
+    end
+
+    it "includes all exception types by default" do
+      ob = Scientist::Observation.new("test", @experiment) do
+        raise Exception.new("not a StandardError")
+      end
+
+      assert ob.raised?
+      assert_instance_of Exception, ob.exception
+    end
+
+    it "can customize rescued types" do
+      Scientist::Observation::RESCUES.replace [StandardError]
+
+      ex = assert_raises Exception do
+        Scientist::Observation.new("test", @experiment) do
+          raise Exception.new("not a StandardError")
+        end
+      end
+
+      assert_equal "not a StandardError", ex.message
+    end
+  end
+
   it "compares values" do
     a = Scientist::Observation.new("test", @experiment) { 1 }
     b = Scientist::Observation.new("test", @experiment) { 1 }


### PR DESCRIPTION
This PR addresses (but doesn't close) https://github.com/github/scientist/issues/60. Right now, `Observation` rescues `Object` when it calls a behavior block. This can be [pretty surprising](https://github.com/github/scientist/pull/61), especially if an unhandled signal or a `SystemExit` is raised inside the block.

The patch introduces a `Scientist::Observation::RESCUES` constant with a value of `[Exception]`. This set of exceptions is used to rescue instead of a hardcoded `Object`. I think we should switch the default value to `[StandardError]` in 2.0.0, here's how to do it in the meantime:

```ruby
Scientist::Observation::RESCUES.replace [StandardError]
```

/cc @djrodgerspryor @strand 
/cc @jesseplusplus, who doesn't show up in the reviewer list