### PR TITLE
Make default experiment not run all `try` paths

### DIFF
--- a/lib/scientist/default.rb
+++ b/lib/scientist/default.rb
@@ -10,9 +10,9 @@ class Scientist::Default
     @name = name
   end
 
-  # Run everything every time.
+  # Don't run experiments.
   def enabled?
-    true
+    false
   end
 
   # Don't publish anything.

--- a/test/scientist/default_test.rb
+++ b/test/scientist/default_test.rb
@@ -3,8 +3,8 @@ describe Scientist::Default do
     @ex = Scientist::Default.new "default"
   end
 
-  it "is always enabled" do
-    assert @ex.enabled?
+  it "is always disabled" do
+    refute @ex.enabled?
   end
 
   it "noops publish" do

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -123,6 +123,11 @@ describe Scientist::Experiment do
   it "re-raises exceptions raised during publish by default" do
     ex = Scientist::Experiment.new("hello")
     assert_kind_of Scientist::Default, ex
+
+    def ex.enabled?
+      true
+    end
+
     def ex.publish(result)
       raise "boomtown"
     end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6259/32519880-c2c5afb0-c3d3-11e7-98dc-f5b46eaeaeb9.png)

It is quite possible to follow the directions in the README, create a local experiment class for your situation, with a real `enabled?` method, `publish` methods, etc., and expect folks to require your library and use it. Maybe you don't understand the gotcha(s) (see below), or just forget -- and you don't include your experiment class automatically. 

But, it's also possible that one of your someones will define an experiment, neglect to include your local experiment override library, still have scientist in the require path, and when they `include Scientist` in their experiment-running class, they will get the "default" scientist experiment, and not yours...

The default experiment runs every `try` branch. In production environments pushing a new experiment and having it run the `try` branch unconditionally is less than ideal...  :rocket: :boom: 

This change flips the default `enabled?` to 'false`.  At least folks will dig a bit to realize they could include their local library by default and dodge this problem.