### PR TITLE
Allow `science` to be called as a module method

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,17 @@ science "various-ways", run: "first-way" do |e|
 end
 ```
 
+### Without including Scientist
+
+If you need to use Scientist in a place where you aren't able to include the Scientist module, you can call `Scientist.run`:
+
+```ruby
+Scientist.run "widget-permissions" do |e|
+  e.use { model.check_user(user).valid? }
+  e.try { user.can?(:read, model) }
+end
+```
+
 ## Hacking
 
 Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs the unit tests. All development dependencies are installed automatically. Science requires Ruby 1.9 or newer.

--- a/lib/scientist.rb
+++ b/lib/scientist.rb
@@ -3,6 +3,9 @@
 # defining and running experiments.
 #
 # If you need to run science on class methods, extend this module instead.
+#
+# If including or extending this module are not an option, call
+# `Scientist.run`.
 module Scientist
   # Define and run a science experiment.
   #
@@ -15,14 +18,33 @@ module Scientist
   #
   # Returns the calculated value of the control experiment, or raises if an
   # exception was raised.
-  def science(name, opts = {})
+  def self.run(name, opts = {})
     experiment = Experiment.new(name)
-    experiment.context(default_scientist_context)
 
     yield experiment
 
     test = opts[:run] if opts
     experiment.run(test)
+  end
+
+  # Define and run a science experiment.
+  #
+  # name - a String name for this experiment.
+  # opts - optional hash with the the named test to run instead of "control",
+  #        :run is the only valid key.
+  #
+  # Yields an object which implements the Scientist::Experiment interface.
+  # See `Scientist::Experiment.new` for how this is defined. The context from
+  # the `default_scientist_context` method will be applied to the experiment.
+  #
+  # Returns the calculated value of the control experiment, or raises if an
+  # exception was raised.
+  def science(name, opts = {})
+    Scientist.run(name, opts) do |experiment|
+      experiment.context(default_scientist_context)
+
+      yield experiment
+    end
   end
 
   # Public: the default context data for an experiment created and run via the

--- a/test/scientist_test.rb
+++ b/test/scientist_test.rb
@@ -15,6 +15,15 @@ describe Scientist do
     assert_equal :control, r
   end
 
+  it "provides a module method to instantiate and run experiments" do
+    r = Scientist.run "test" do |e|
+      e.use { :control }
+      e.try { :candidate }
+    end
+
+    assert_equal :control, r
+  end
+
   it "provides an empty default_scientist_context" do
     obj = Object.new
     obj.extend(Scientist)


### PR DESCRIPTION
There are some cases where `include Scientist` isn't an option -- such as inside of DSL blocks -- so it is useful to be able to call the `science` method with `Scientist` itself as the receiver.