### PR TITLE
When raising MismatchError, use cleaned value

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -44,7 +44,7 @@ module Scientist::Experiment
         observation.exception.inspect.prepend("  ") + "\n" +
           observation.exception.backtrace.map { |line| line.prepend("    ") }.join("\n")
       else
-        observation.value.inspect.prepend("  ")
+        observation.cleaned_value.inspect.prepend("  ")
       end
     end
   end

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -392,6 +392,16 @@ describe Scientist::Experiment do
       assert_raises(Scientist::Experiment::MismatchError) { @ex.run }
     end
 
+    it "cleans values when raising on observation mismatch" do
+      Fake.raise_on_mismatches = true
+      @ex.use { "fine" }
+      @ex.try { "not fine" }
+      @ex.clean { "So Clean" }
+
+      err = assert_raises(Scientist::Experiment::MismatchError) { @ex.run }
+      assert_match /So Clean/, err.message
+    end
+
     it "doesn't raise when there is a mismatch if raise on mismatches is disabled" do
       Fake.raise_on_mismatches = false
       @ex.use { "fine" }


### PR DESCRIPTION
When raising `MismatchError`, use the cleaned value in the error message instead of the uncleaned value.

This way, error messages are more helpful when observation values are large ruby objects!

TDD  - Error after adding test but before changing implementation to `cleaned_value`

```
# Running:

.............................................F.................................

Finished in 0.278490s, 283.6727 runs/s, 563.7545 assertions/s.

  1) Failure:
Scientist::Experiment::raising on mismatches#test_0002_cleans values when raising on observation mismatch [test/scientist/experiment_test.rb:402]:
Expected /So Clean/ to match "experiment 'experiment' observations mismatched:\ncontrol:\n  \"fine\"\ncandidate:\n  \"not fine\"\n".
```

cc @zerowidth 