### PR TITLE
README fix: below -> above

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ class MyExperiment
       }
     else
       {
-        # see "Keeping it clean" below
+        # see "Keeping it clean" above
         :value => observation.cleaned_value
       }
     end


### PR DESCRIPTION
The "Keeping it clean" section is placed before (above), not after (below).