### PR TITLE
Add raise_with to scientist:

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,14 +357,23 @@ Scientist will raise a `Scientist::Experiment::MismatchError` exception if any o
 To instruct Scientist to raise a custom error instead of the default `Scientist::Experiment::MismatchError`:
 
 ```ruby
-Class CustomError < Scientist::Experiment::MismatchError
+class CustomMismatchError < Scientist::Experiment::MismatchError
   def to_s
-    ...
+    result.candidates.map do |candidate|
+      puts "There was a mismatch! Here's the diff:"
+      Diff.new(result.control, candidate)
+    end
   end
 end
+```
 
+```ruby
 science "widget-permissions" do |e|
-  e.raise_with(CustomError)
+  e.context :user => user
+
+  e.use { model.check_user(user).valid? }
+  e.try { user.can?(:read, model) }
+  e.raise_with CustomMismatchError
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -359,10 +359,13 @@ To instruct Scientist to raise a custom error instead of the default `Scientist:
 ```ruby
 class CustomMismatchError < Scientist::Experiment::MismatchError
   def to_s
-    result.candidates.map do |candidate|
-      puts "There was a mismatch! Here's the diff:"
+    message = "There was a mismatch! Here's the diff:"
+
+    diffs = result.candidates.map do |candidate|
       Diff.new(result.control, candidate)
     end.join("\n")
+
+    "#{message}\n#{diffs}"
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -372,10 +372,9 @@ end
 
 ```ruby
 science "widget-permissions" do |e|
-  e.context :user => user
+  e.use { Report.find(id) }
+  e.try { ReportService.new.fetch(id) }
 
-  e.use { model.check_user(user).valid? }
-  e.try { user.can?(:read, model) }
   e.raise_with CustomMismatchError
 end
 ```

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ class CustomMismatchError < Scientist::Experiment::MismatchError
     result.candidates.map do |candidate|
       puts "There was a mismatch! Here's the diff:"
       Diff.new(result.control, candidate)
-    end
+    end.join("\n")
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ MyExperiment.raise_on_mismatches = true
 
 Scientist will raise a `Scientist::Experiment::MismatchError` exception if any observations don't match.
 
-## Custom mismatch errors
+#### Custom mismatch errors
 
 To instruct Scientist to raise a custom error instead of the default `Scientist::Experiment::MismatchError`:
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,24 @@ MyExperiment.raise_on_mismatches = true
 
 Scientist will raise a `Scientist::Experiment::MismatchError` exception if any observations don't match.
 
+## Custom mismatch errors
+
+To instruct Scientist to raise a custom error instead of the default `Scientist::Experiment::MismatchError`:
+
+```ruby
+Class CustomError < Scientist::Experiment::MismatchError
+  def to_s
+    ...
+  end
+end
+
+science "widget-permissions" do |e|
+  e.raise_with(CustomError)
+end
+```
+
+This allows for pre-processing on mismatch error exception messages.
+
 ### Handling errors
 
 #### In candidate code

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -176,6 +176,10 @@ module Scientist::Experiment
     false
   end
 
+  def raise_with(exception)
+    @_scientist_custom_mismatch_error = exception
+  end
+
   # Called when an exception is raised while running an internal operation,
   # like :publish. Override this method to track these exceptions. The
   # default implementation re-raises the exception.
@@ -223,7 +227,11 @@ module Scientist::Experiment
     end
 
     if raise_on_mismatches? && result.mismatched?
-      raise MismatchError.new(self.name, result)
+      if @_scientist_custom_mismatch_error
+        raise @_scientist_custom_mismatch_error.new(self.name, result)
+      else
+        raise MismatchError.new(self.name, result)
+      end
     end
 
     if control.raised?

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -262,6 +262,19 @@ describe Scientist::Experiment do
     assert_equal "kaboom", exception.message
   end
 
+  describe "#raise_with" do
+    it "raises custom error if provided" do
+      class CustomError < Scientist::Experiment::MismatchError; end
+
+      @ex.use { 1}
+      @ex.try { 2 }
+      @ex.raise_with(CustomError)
+      @ex.raise_on_mismatches = true
+
+      assert_raises(CustomError) { @ex.run }
+    end
+  end
+
   describe "#run_if" do
     it "does not run the experiment if the given block returns false" do
       candidate_ran = false

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -264,9 +264,9 @@ describe Scientist::Experiment do
 
   describe "#raise_with" do
     it "raises custom error if provided" do
-      class CustomError < Scientist::Experiment::MismatchError; end
+      CustomError = Class.new(Scientist::Experiment::MismatchError)
 
-      @ex.use { 1}
+      @ex.use { 1 }
       @ex.try { 2 }
       @ex.raise_with(CustomError)
       @ex.raise_on_mismatches = true


### PR DESCRIPTION
Adds `raise_with` to `Experiment`, allowing users to set an alternative `MismatchError`. This allows for more control over how mismatch errors are reported in test suites.

cc @bswinnerton @zerowidth 