### PR TITLE
added swift version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs t
 - [calavera/go-scientist](https://github.com/calavera/go-scientist) (Go)
 - [jelmersnoeck/experiment](https://github.com/jelmersnoeck/experiment) (Go)
 - [spoptchev/scientist](https://github.com/spoptchev/scientist) (Kotlin / Java)
+- [junkpiano/scientist](https://github.com/junkpiano/scientist) (Swift)
 
 
 ## Maintainers


### PR DESCRIPTION
Hi all,

I made Swift version of `scientist` since nobody has ever created.
Now that it's done, I want to add mine to the list.

Here is the things of my `scientist`.

Ruby is not statically typed language, but Swift is. That's why I decided to use generic type for return values to support features written in Ruby as much as possible. And to compare results, the type of return values must conform to `Equatable`. The benefit of these constraints let me create type-safe library.