### PR TITLE
Prefer building new strings over mutation

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -41,10 +41,10 @@ module Scientist::Experiment
     def format_observation(observation)
       observation.name + ":\n" +
       if observation.raised?
-        observation.exception.inspect.prepend("  ") + "\n" +
-          observation.exception.backtrace.map { |line| line.prepend("    ") }.join("\n")
+        lines = observation.exception.backtrace.map { |line| "    #{line}" }.join("\n")
+        "  #{observation.exception.inspect}" + "\n" + lines
       else
-        observation.cleaned_value.inspect.prepend("  ")
+        "  #{observation.cleaned_value.inspect}"
       end
     end
   end


### PR DESCRIPTION
# Problem

Use of scientist may result in `FrozenError`s if strings used in observations are frozen.

# Solution

Build new strings using interpolation rather than String#prepend which mutates the original string.