### PR TITLE
Do not use `String#prepend`, as it modifies the string.

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -41,10 +41,10 @@ module Scientist::Experiment
     def format_observation(observation)
       observation.name + ":\n" +
       if observation.raised?
-        observation.exception.inspect.prepend("  ") + "\n" +
-          observation.exception.backtrace.map { |line| line.prepend("    ") }.join("\n")
+        "  " + observation.exception.inspect + "\n" +
+          observation.exception.backtrace.map { |line| "    " + line }.join("\n")
       else
-        observation.cleaned_value.inspect.prepend("  ")
+        "  " + observation.cleaned_value.inspect
       end
     end
   end


### PR DESCRIPTION
I just ran into this. If `#inspect` on a candidate or control value returns a frozen string, the `format_observation` method blows up. 💥

In general, it's just good form not to modify values in-place that we didn't create ourselves. 🤷‍♂️ 