### PR TITLE
Update ruby to be tested with CI to the latest version and remove old ruby from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ language: ruby
 cache: bundler
 script: script/test
 rvm:
-  - 2.1.10
-  - 2.2.9
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
 before_install: gem install bundler
 addons:
  apt:

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ end
 
 ## Hacking
 
-Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs the unit tests. All development dependencies are installed automatically. Scientist requires Ruby 2.1 or newer.
+Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs the unit tests. All development dependencies are installed automatically. Scientist requires Ruby 2.3 or newer.
 
 ## Alternatives
 

--- a/scientist.gemspec
+++ b/scientist.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/github/scientist"
   gem.license       = "MIT"
 
-  gem.required_ruby_version = '>= 2.1'
+  gem.required_ruby_version = '>= 2.3'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = []

--- a/script/test
+++ b/script/test
@@ -4,7 +4,7 @@
 set -e
 
 cd $(dirname "$0")/..
-  script/bootstrap && ruby -I lib \
+  script/bootstrap && bundle exec ruby -I lib \
     -e 'require "bundler/setup"' \
     -e 'require "coveralls"; Coveralls.wear!{ add_filter ".bundle" }' \
     -e 'require "minitest/autorun"' \


### PR DESCRIPTION
Hi. 

This gem's CI is failed due to old version ruby tests.
Since, I'd like to propose that ruby 2.1 and 2.2 remove from CI target...

In addition, I have updated Maintenance ruby's to the latest version.

Thanks.