### PR TITLE
Actually test which blocks `Scientist.run` runs

### DIFF
--- a/test/scientist_test.rb
+++ b/test/scientist_test.rb
@@ -56,27 +56,33 @@ describe Scientist do
     obj = Object.new
     obj.extend(Scientist)
 
+    behaviors_executed = []
+
     result = obj.science "test", run: "first-way" do |e|
       experiment = e
 
-      e.try("first-way") { true }
-      e.try("second-way") { true }
+      e.try("first-way") { behaviors_executed << "first-way" ; true }
+      e.try("second-way") { behaviors_executed << "second-way" ; true }
     end
 
     assert_equal true, result
+    assert_equal [ "first-way" ], behaviors_executed
   end
 
   it "runs control when there is a nil named test" do
     obj = Object.new
     obj.extend(Scientist)
 
+    behaviors_executed = []
+
     result = obj.science "test", nil do |e|
       experiment = e
 
-      e.use { true }
-      e.try("second-way") { true }
+      e.use { behaviors_executed << "control" ; true }
+      e.try("second-way") { behaviors_executed << "second-way" ; true }
     end
 
     assert_equal true, result
+    assert_equal [ "control" ], behaviors_executed
   end
 end


### PR DESCRIPTION
When I change `lib/scientist.rb` line 27 from:
  `experiment.run(test)`
to:
  `experiment.run`

and run only the tests in `test/scientist_test.rb` file...

- `it "runs control when there is a nil named test"` passes, and
- `it "runs the named test instead of the control"` fails, BUT not because it failed an assertion -- instead it raises Scientist::BehaviorMissing, which doesn't *directly* point to what the test purports to be testing.

(If I compound my sins by changing Experiment to return `true` instead of raising the BehaviorMissing error, both tests pass.  Granted, other tests on Experiment fail, so not all is gloom.)

The test suite overall probably appeared to do what it was supposed to in a TDD cycle -- namely, fail without the intended behavior, then pass once the behavior was implemented.  However, that behavior is only tested indirectly, and the tests are misleading to a new reader. These two specific tests, as well, may not properly prevent regressions.

I've changed these two tests so that they capture what I believe to be the actual intent as expressed in the test names -- namely, that one block is executed and the other is not.

I don't love the visual clutter, but I don't see a better way around it without using mocks, which would be considerably more fraught.  :)