### PR TITLE
Simplify configuration with Scientist::Experiment.register convenience method

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ class MyExperiment
 
   attr_accessor :name
 
-  def initialize(name:)
+  def initialize(name)
     @name = name
   end
 
@@ -77,12 +77,7 @@ class MyExperiment
   end
 end
 
-# replace `Scientist::Default` as the default implementation
-module Scientist::Experiment
-  def self.new(name)
-    MyExperiment.new(name: name)
-  end
-end
+Scientist::Experiment.register(MyExperiment)
 ```
 
 Now calls to the `science` helper will load instances of `MyExperiment`.
@@ -256,7 +251,7 @@ class MyExperiment
 
   attr_accessor :name, :percent_enabled
 
-  def initialize(name:)
+  def initialize(name)
     @name = name
     @percent_enabled = 100
   end

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ class MyExperiment
     p result
   end
 end
-
-Scientist::Experiment.register(MyExperiment)
 ```
 
 Now calls to the `science` helper will load instances of `MyExperiment`.

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -10,11 +10,11 @@ module Scientist::Experiment
   attr_accessor :raise_on_mismatches
 
   def self.included(base)
-    self.register(base)
+    self.set_default(base)
     base.extend RaiseOnMismatch
   end
 
-  # Instantiate a new experiment (using the class given to the .register method).
+  # Instantiate a new experiment (using the class given to the .set_default method).
   def self.new(name)
     (@experiment_klass || Scientist::Default).new(name)
   end
@@ -23,7 +23,7 @@ module Scientist::Experiment
   # (must implement the Scientist::Experiment interface).
   #
   # Called automatically when new experiments are defined.
-  def self.register(klass)
+  def self.set_default(klass)
     @experiment_klass = klass
   end
 

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -9,12 +9,15 @@ module Scientist::Experiment
   # If this is nil, raise_on_mismatches class attribute is used instead.
   attr_accessor :raise_on_mismatches
 
-  # Create a new instance of a class that implements the Scientist::Experiment
-  # interface.
-  #
-  # Override this method directly to change the default implementation.
+  # Instantiate a new experiment (using the class given to the .register method).
   def self.new(name)
-    Scientist::Default.new(name)
+    (@experiment_klass || Scientist::Default).new(name)
+  end
+
+  # Configure Scientist to use the given class for all future experiments
+  # (must implement the Scientist::Experiment interface).
+  def self.register(klass)
+    @experiment_klass = klass
   end
 
   # A mismatch, raised when raise_on_mismatches is enabled.

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -9,6 +9,11 @@ module Scientist::Experiment
   # If this is nil, raise_on_mismatches class attribute is used instead.
   attr_accessor :raise_on_mismatches
 
+  def self.included(base)
+    self.register(base)
+    base.extend RaiseOnMismatch
+  end
+
   # Instantiate a new experiment (using the class given to the .register method).
   def self.new(name)
     (@experiment_klass || Scientist::Default).new(name)
@@ -16,6 +21,8 @@ module Scientist::Experiment
 
   # Configure Scientist to use the given class for all future experiments
   # (must implement the Scientist::Experiment interface).
+  #
+  # Called automatically when new experiments are defined.
   def self.register(klass)
     @experiment_klass = klass
   end
@@ -68,10 +75,6 @@ module Scientist::Experiment
     def raise_on_mismatches?
       @raise_on_mismatches
     end
-  end
-
-  def self.included(base)
-    base.extend RaiseOnMismatch
   end
 
   # Define a block of code to run before an experiment begins, if the experiment

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -3,7 +3,7 @@ describe Scientist::Experiment do
     include Scientist::Experiment
 
     # Undo auto-config magic / preserve default behavior of Scientist::Experiment.new
-    Scientist::Experiment.register(nil)
+    Scientist::Experiment.set_default(nil)
 
     def initialize(*args)
     end

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -2,6 +2,9 @@ describe Scientist::Experiment do
   class Fake
     include Scientist::Experiment
 
+    # Undo auto-config magic / preserve default behavior of Scientist::Experiment.new
+    Scientist::Experiment.register(nil)
+
     def initialize(*args)
     end
 


### PR DESCRIPTION
I thought it was kind of clumsy to have to override `Scientist::Experiment.new` when configuring Scientist, so I created a `Scientist::Experiment.register` method to reduce the last five lines of configuration down to one.

In the second commit on this PR, I automate the registration of new experiments via a `self.included` callback, meaning that last line of configuration can be removed entirely.

I believe these changes should be fully backward-compatible with the previous API, since the original approach was to manually override `Scientist::Experiment.new` anyway.