### PR TITLE
Make MismatchError a base Exception

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -18,7 +18,7 @@ module Scientist::Experiment
   end
 
   # A mismatch, raised when raise_on_mismatches is enabled.
-  class MismatchError < StandardError
+  class MismatchError < Exception
     attr_reader :name, :result
 
     def initialize(name, result)

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -444,6 +444,18 @@ describe Scientist::Experiment do
       assert_raises(Scientist::Experiment::MismatchError) { @ex.run }
     end
 
+    it "allows MismatchError to bubble up through bare rescues" do
+      Fake.raise_on_mismatches = true
+      @ex.use { "control" }
+      @ex.try { "candidate" }
+      runner = -> do
+        @ex.run
+      rescue
+        # StandardError handled
+      end
+      assert_raises(Scientist::Experiment::MismatchError) { runner.call }
+    end
+
     describe "#raise_on_mismatches?" do
       it "raises when there is a mismatch if the experiment instance's raise on mismatches is enabled" do
         Fake.raise_on_mismatches = false

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -448,11 +448,13 @@ describe Scientist::Experiment do
       Fake.raise_on_mismatches = true
       @ex.use { "control" }
       @ex.try { "candidate" }
-      runner = -> do
-        @ex.run
-      rescue
-        # StandardError handled
-      end
+      runner = -> {
+        begin
+          @ex.run
+        rescue
+          # StandardError handled
+        end
+      }
       assert_raises(Scientist::Experiment::MismatchError) { runner.call }
     end
 


### PR DESCRIPTION
## Problem

In my experience the scientist gem is very useful with legacy and complicated code bases. I have found success in adding an experiment and levering the test suite along with production to identify mis-placed expectations and adjust. However, in some cases these code bases make the unfortunate decision to use bare `rescue => e` constructs for reasons. Since scientist's `MismatchError` inherits from `StandardError` it will be caught up by such rescues. If I'm not mistaken, the purpose of this error (which is off by default) is to increase the visibility of mismatches, particularly in test suites. If possible, they should avoid being rescued similar to how certain RSpec errors behavior.

## Solution

Update `MismatchError` to inherit from `Exception` so that it isn't handled by a bare `rescue => e`. I'll admit there are subtleties here that I probably don't fully appreciate, so I offer this solution as the start of a conversation.

Thank you for the wonderful library!  ❤️💙💚💛💜