### PR TITLE
Add TrueWill/tzientist to Alternatives in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs t
 - [tomiaijo/scientist](https://github.com/tomiaijo/scientist) (C++)
 - [trello/scientist](https://github.com/trello/scientist) (node.js)
 - [ziyasal/scientist.js](https://github.com/ziyasal/scientist.js) (node.js, ES6)
+- [TrueWill/tzientist](https://github.com/TrueWill/tzientist) (node.js, TypeScript)
 - [yeller/laboratory](https://github.com/yeller/laboratory) (Clojure)
 - [lancew/Scientist](https://github.com/lancew/Scientist) (Perl 5)
 - [lancew/ScientistP6](https://github.com/lancew/ScientistP6) (Perl 6)


### PR DESCRIPTION
I have a new open source project that I would like to add to the list of alternatives for Scientist for other languages.

https://github.com/TrueWill/tzientist

This PR updates the README to add my project to the list.

Thank you!