### PR TITLE
Add duration unit to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Wrap a `use` block around the code's original behavior, and wrap `try` around th
 
 * It decides whether or not to run the `try` block,
 * Randomizes the order in which `use` and `try` blocks are run,
-* Measures the durations of all behaviors,
+* Measures the durations of all behaviors in seconds,
 * Compares the result of `try` to the result of `use`,
 * Swallow and record exceptions raised in the `try` block when overriding `raised`, and
 * Publishes all this information.


### PR DESCRIPTION
Hi folks, this PR is pretty simple. It just clarifies that the unit for `Scientist::Observation#duration` is in seconds. I couldn't find this anywhere else in the docs, so I figured others would appreciate not needing to dig around in the code to verify. 