### PR TITLE
Don’t set default when included in modules

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -10,7 +10,7 @@ module Scientist::Experiment
   attr_accessor :raise_on_mismatches
 
   def self.included(base)
-    self.set_default(base)
+    self.set_default(base) if base.instance_of?(Class)
     base.extend RaiseOnMismatch
   end
 

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -31,6 +31,24 @@ describe Scientist::Experiment do
     @ex = Fake.new
   end
 
+  it "sets the default on inclusion" do
+    klass = Class.new do
+      include Scientist::Experiment
+
+      def initialize(name)
+      end
+    end
+
+    assert_kind_of klass, Scientist::Experiment.new("hello")
+
+    Scientist::Experiment.set_default(nil)
+  end
+
+  it "doesn't set the default on inclusion when it's a module" do
+    Module.new { include Scientist::Experiment }
+    assert_kind_of Scientist::Default, Scientist::Experiment.new("hello")
+  end
+
   it "has a default implementation" do
     ex = Scientist::Experiment.new("hello")
     assert_kind_of Scientist::Default, ex


### PR DESCRIPTION
This came up recently on some work on gitlab, where we're using scientist for some of our experimentation work.

Ultimately I was extracting some of the base experiment behavior into a module, and realize that in doing this, it sets the default `@experiment_klass` to a module, and that breaks when trying to use the `science` method. So basically it doesn't seem like the `included` callback should be setting the default class if it's a module.

The only way to get around this is to:

```ruby
module MyModule
  Scientist::Experiment.send(:append_features, self)
  extend Scientist::Experiment::RaiseOnMismatch

  #... implementation
end
```

Which doesn't really seem right. I know we can do `Scientist::Experiment.set_default(nil)`, but that then has load order implications and so we just don't want the behavior in general and feel like we're trying to work around a convenience that's actually somewhat hard to work around.

Thoughts?