### PR TITLE
CI: Add Ruby 2.7 and 3.0 to the matrix, drop EOL Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ cache: bundler
 script: script/test
 rvm:
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.4.10
+  - 2.5.9
+  - 2.6.7
+  - 2.7.3
+  - 3.0.1
   - truffleruby-head
 before_install: gem install bundler
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: ruby
 cache: bundler
 script: script/test
 rvm:
-  - 2.3.8
-  - 2.4.10
-  - 2.5.9
   - 2.6.7
   - 2.7.3
   - 3.0.1


### PR DESCRIPTION
This PR adds Ruby versions **2.7** and **3.0** to the CI matrix.

In addition, the version numbers for the matrix are now updated to the latest patch versions.

Source for the version numbers known by rvm: https://github.com/rvm/rvm/blob/master/config/known#L12

---

**Suggestion**: Perhaps fewer versions can be in here? **Update**: Dropped EOL Ruby versions, too.