### PR TITLE
แนวคิด

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.1
+  - truffleruby-head
 before_install: gem install bundler
 addons:
  apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ language: ruby
 cache: bundler
 script: script/test
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.6.7
+  - 2.7.3
+  - 3.0.1
   - truffleruby-head
 before_install: gem install bundler
 addons:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ class MyExperiment
 end
 ```
 
+When `Scientist::Experiment` is included in a class, it automatically sets it as the default implementation via `Scientist::Experiment.set_default`. This `set_default` call is is skipped if you include `Scientist::Experiment` in a module.
+
 Now calls to the `science` helper will load instances of `MyExperiment`.
 
 ### Controlling comparison

--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ Be on a Unixy box. Make sure a modern Bundler is available. `script/test` runs t
 - [spoptchev/scientist](https://github.com/spoptchev/scientist) (Kotlin / Java)
 - [junkpiano/scientist](https://github.com/junkpiano/scientist) (Swift)
 - [serverless scientist](http://serverlessscientist.com/) (AWS Lambda)
+- [fightmegg/scientist](https://github.com/fightmegg/scientist) (TypeScript, Browser / Node.js)
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Wrap a `use` block around the code's original behavior, and wrap `try` around th
 
 * It decides whether or not to run the `try` block,
 * Randomizes the order in which `use` and `try` blocks are run,
-* Measures the durations of all behaviors,
+* Measures the durations of all behaviors in seconds,
 * Compares the result of `try` to the result of `use`,
 * Swallow and record exceptions raised in the `try` block when overriding `raised`, and
 * Publishes all this information.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ class MyExperiment
 
   attr_accessor :name
 
-  def initialize(name:)
+  def initialize(name)
     @name = name
   end
 
@@ -80,13 +80,6 @@ class MyExperiment
   def publish(result)
     # see "Publishing results" below
     p result
-  end
-end
-
-# replace `Scientist::Default` as the default implementation
-module Scientist::Experiment
-  def self.new(name)
-    MyExperiment.new(name: name)
   end
 end
 ```
@@ -262,7 +255,7 @@ class MyExperiment
 
   attr_accessor :name, :percent_enabled
 
-  def initialize(name:)
+  def initialize(name)
     @name = name
     @percent_enabled = 100
   end

--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ Scientist rescues and tracks _all_ exceptions raised in a `try` or `use` block, 
 Scientist::Observation::RESCUES.replace [StandardError]
 ```
 
+**Timeout ⏲️**: If you're introducing a candidate that could possibly timeout, use caution. ⚠️ While Scientist rescues all exceptions that occur in the candidate block, it *does not* protect you from timeouts, as doing so would be complicated. It would likely require running the candidate code in a background job and tracking the time of a request. We feel the cost of this complexity would outweigh the benefit, so make sure that your code doesn't cause timeouts. This risk can be reduced by running the experiment on a low percentage so that users can (most likely) bypass the experiment by refreshing the page if they hit a timeout. See [Ramping up experiments](#ramping-up-experiments) below for how details on how to set the percentage for your experiment.
+
 #### In a Scientist callback
 
 If an exception is raised within any of Scientist's internal helpers, like `publish`, `compare`, or `clean`, the `raised` method is called with the symbol name of the internal operation that failed and the exception that was raised. The default behavior of `Scientist::Default` is to simply re-raise the exception. Since this halts the experiment entirely, it's often a better idea to handle this error and continue so the experiment as a whole isn't canceled entirely:

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -10,7 +10,7 @@ module Scientist::Experiment
   attr_accessor :raise_on_mismatches
 
   def self.included(base)
-    self.set_default(base)
+    self.set_default(base) if base.instance_of?(Class)
     base.extend RaiseOnMismatch
   end
 

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -9,12 +9,22 @@ module Scientist::Experiment
   # If this is nil, raise_on_mismatches class attribute is used instead.
   attr_accessor :raise_on_mismatches
 
-  # Create a new instance of a class that implements the Scientist::Experiment
-  # interface.
-  #
-  # Override this method directly to change the default implementation.
+  def self.included(base)
+    self.set_default(base)
+    base.extend RaiseOnMismatch
+  end
+
+  # Instantiate a new experiment (using the class given to the .set_default method).
   def self.new(name)
-    Scientist::Default.new(name)
+    (@experiment_klass || Scientist::Default).new(name)
+  end
+
+  # Configure Scientist to use the given class for all future experiments
+  # (must implement the Scientist::Experiment interface).
+  #
+  # Called automatically when new experiments are defined.
+  def self.set_default(klass)
+    @experiment_klass = klass
   end
 
   # A mismatch, raised when raise_on_mismatches is enabled.
@@ -65,10 +75,6 @@ module Scientist::Experiment
     def raise_on_mismatches?
       @raise_on_mismatches
     end
-  end
-
-  def self.included(base)
-    base.extend RaiseOnMismatch
   end
 
   # Define a block of code to run before an experiment begins, if the experiment

--- a/lib/scientist/version.rb
+++ b/lib/scientist/version.rb
@@ -1,3 +1,3 @@
 module Scientist
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end

--- a/lib/scientist/version.rb
+++ b/lib/scientist/version.rb
@@ -1,3 +1,3 @@
 module Scientist
-  VERSION = "1.5.0"
+  VERSION = "1.6.0"
 end

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -549,7 +549,7 @@ candidate:
         assert_equal "  \"value\"", lines[2]
         assert_equal "candidate:", lines[3]
         assert_equal "  #<RuntimeError: error>", lines[4]
-        assert_match %r(    test/scientist/experiment_test.rb:\d+:in `block), lines[5]
+        assert_match %r(test/scientist/experiment_test.rb:\d+:in `block), lines[5]
       end
     end
   end

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -2,6 +2,9 @@ describe Scientist::Experiment do
   class Fake
     include Scientist::Experiment
 
+    # Undo auto-config magic / preserve default behavior of Scientist::Experiment.new
+    Scientist::Experiment.set_default(nil)
+
     def initialize(*args)
     end
 

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -31,6 +31,24 @@ describe Scientist::Experiment do
     @ex = Fake.new
   end
 
+  it "sets the default on inclusion" do
+    klass = Class.new do
+      include Scientist::Experiment
+
+      def initialize(name)
+      end
+    end
+
+    assert_kind_of klass, Scientist::Experiment.new("hello")
+
+    Scientist::Experiment.set_default(nil)
+  end
+
+  it "doesn't set the default on inclusion when it's a module" do
+    Module.new { include Scientist::Experiment }
+    assert_kind_of Scientist::Default, Scientist::Experiment.new("hello")
+  end
+
   it "has a default implementation" do
     ex = Scientist::Experiment.new("hello")
     assert_kind_of Scientist::Default, ex


### PR DESCRIPTION
นักวิทยาศาสตร์!
ไลบรารี Ruby สำหรับการปรับโครงสร้างเส้นทางที่สำคัญอย่างรอบคอบ สร้างสถานะ Build สถานะความคุ้มครอง

ฉันจะวิทยาศาสตร์ได้อย่างไร
สมมติว่าคุณกำลังเปลี่ยนวิธีจัดการการอนุญาตในเว็บแอปขนาดใหญ่ การทดสอบสามารถช่วยชี้แนะการรีแฟคเตอร์ของคุณได้ แต่คุณต้องการเปรียบเทียบพฤติกรรมปัจจุบันและการปรับโครงสร้างใหม่ภายใต้ภาระงานจริงๆ

ต้องการ "นักวิทยาศาสตร์"

คลาส MyWidget 
  def  อนุญาตหรือไม่ ( ผู้ใช้) 
    ทดลอง =  นักวิทยาศาสตร์ :: เริ่มต้น ใหม่"เครื่องมือ-สิทธิ์" การทดลอง ใช้{ model . check_user? ( ผู้ใช้) . ถูกต้อง? } # วิธีการแบบเก่าทดลอง ลอง{ ผู้ใช้. สามารถ? ( :read , model ) } # วิธีใหม่ 
        
         

    การทดลอง วิ่ง
  จบ
สิ้น
ห่อuseบล็อกรอบพฤติกรรมเดิมของรหัสและตัดtryรอบการทำงานใหม่ experiment.runจะส่งคืนสิ่งที่useบล็อกกลับมาเสมอแต่มันทำสิ่งต่าง ๆ อยู่เบื้องหลัง:

มันตัดสินใจว่าจะเรียกใช้tryบล็อกหรือไม่
สุ่มลำดับการทำงานuseและtryบล็อก
วัดระยะเวลาของพฤติกรรมทั้งหมดเป็นวินาที
เปรียบเทียบผลลัพธ์ของtryกับผลลัพธ์ของuse,
กลืนและบันทึกข้อยกเว้นที่เกิดขึ้นในtryบล็อกเมื่อแทนที่raised, และ
เผยแพร่ข้อมูลทั้งหมดนี้
useบล็อกที่เรียกว่าการควบคุม tryบล็อกที่เรียกว่าผู้สมัคร

การสร้างการทดสอบนั้นใช้ถ้อยคำค่อนข้างมาก แต่เมื่อคุณรวมScientistโมดูลscienceผู้ช่วยจะสร้างการทดลองและโทรrunหาคุณ:

ต้องการ "นักวิทยาศาสตร์"

คลาส MyWidget 
  รวมถึง Scientist

  def  อนุญาต? ( ผู้ใช้) 
    วิทยาศาสตร์ "อนุญาตวิดเจ็ต"  ทำ | การทดลอง |
      การทดลอง ใช้{ model . check_user ( ผู้ใช้) ถูกต้อง? } # วิธีการแบบเก่าทดลอง ลอง{ ผู้ใช้. สามารถ? ( :read , model ) } # new way end # ส่งกลับค่าควบคุมend end    
           
     
  
ถ้าคุณไม่ประกาศtryบล็อคใดๆเครื่องจักรของ Scientist จะไม่ถูกเรียกใช้และค่าควบคุมจะถูกส่งคืนเสมอ

ทำให้วิทยาศาสตร์มีประโยชน์
ตัวอย่างข้างต้นจะทำงาน แต่จริงๆ แล้วพวกเขาไม่ได้ทำอะไรเลย tryบล็อกไม่ได้ทำงานและยังไม่มีผลการค้นหาได้รับการตีพิมพ์ แทนที่การใช้การทดสอบเริ่มต้นเพื่อควบคุมการดำเนินการและการรายงาน:

ต้องการ "นักวิทยาศาสตร์/การทดลอง"

class  MyExperiment 
  รวม Scientist :: Experiment

  attr_accessor  :name

  def  เริ่มต้น( ชื่อ) 
    @name  =  ชื่อ
  end

   เปิดใช้งาน
    def ? # ดู "เพิ่มการทดลอง" ด้านล่าง
    สุดจริง true
  

  def  ยก( การดำเนินงาน,  ข้อผิดพลาด) 
    # ดู "ในการเรียกกลับนักวิทยาศาสตร์" ด้านล่าง
    หน้า "การดำเนินการ ' # { การดำเนิน} ' ล้มเหลวด้วยข้อผิดพลาด ' # { ข้อผิดพลาด. ตรวจสอบ} " 
    ซุปเปอร์ # จะ re-ยก
  ท้าย

  def  publish ( ผลลัพธ์) 
    # ดู "การเผยแพร่ผลลัพธ์" ด้านล่าง
    p  ผลลัพธ์
  end 
end
When Scientist::Experiment is included in a class, it automatically sets it as the default implementation via Scientist::Experiment.set_default. This set_default call is is skipped if you include Scientist::Experiment in a module.

Now calls to the science helper will load instances of MyExperiment.

Controlling comparison
Scientist compares control and candidate values using ==. To override this behavior, use compare to define how to compare observed values instead:

class MyWidget
  include Scientist

  def users
    science "users" do |e|
      e.use { User.all }         # returns User instances
      e.try { UserService.list } # returns UserService::User instances

      e.compare do |control, candidate|
        control.map(&:login) == candidate.map(&:login)
      end
    end
  end
end
Adding context
Results aren't very useful without some way to identify them. Use the context method to add to or retrieve the context for an experiment:

science "widget-permissions" do |e|
  e.context :user => user

  e.use { model.check_user(user).valid? }
  e.try { user.can?(:read, model) }
end
context takes a Symbol-keyed Hash of extra data. The data is available in Experiment#publish via the context method. If you're using the science helper a lot in a class, you can provide a default context:

class MyWidget
  include Scientist

  def allows?(user)
    science "widget-permissions" do |e|
      e.context :user => user

      e.use { model.check_user(user).valid? }
      e.try { user.can?(:read, model) }
    end
  end

  def destroy
    science "widget-destruction" do |e|
      e.use { old_scary_destroy }
      e.try { new_safe_destroy }
    end
  end

  def default_scientist_context
    { :widget => self }
  end
end
The widget-permissions and widget-destruction experiments will both have a :widget key in their contexts.

Expensive setup
If an experiment requires expensive setup that should only occur when the experiment is going to be run, define it with the before_run method:

# Code under test modifies this in-place. We want to copy it for the
# candidate code, but only when needed:
value_for_original_code = big_object
value_for_new_code      = nil

science "expensive-but-worthwhile" do |e|
  e.before_run do
    value_for_new_code = big_object.deep_copy
  end
  e.use { original_code(value_for_original_code) }
  e.try { new_code(value_for_new_code) }
end
รักษาความสะอาด
บางครั้งคุณไม่ต้องการเก็บค่าทั้งหมดไว้สำหรับการวิเคราะห์ในภายหลัง ตัวอย่างเช่น การทดสอบอาจส่งกลับUserอินสแตนซ์ แต่เมื่อค้นคว้าข้อมูลที่ไม่ตรงกัน สิ่งที่คุณสนใจก็คือการเข้าสู่ระบบ คุณสามารถกำหนดวิธีการล้างค่าเหล่านี้ในการทดสอบ:

คลาส MyWidget 
  รวมถึง Scientist

  def  ผู้ใช้
    วิทยาศาสตร์ "ผู้ใช้"  ทำ | อี |
      อี ใช้{ ผู้ใช้. ทั้งหมด} อี ลอง{ UserService . รายการ}   
         

      อี ทำสะอาด  | ค่า |
        ค่า. แผนที่( & : เข้าสู่ระบบ) จัดเรียงปลายปลายปลายปลาย
      
    
  
และค่าที่ทำความสะอาดนี้มีให้ในการสังเกตในผลลัพธ์ที่เผยแพร่ขั้นสุดท้าย:

class  MyExperiment 
  รวม Scientist :: Experiment

  # ...

  def  เผยแพร่( ผล) 
    ผล ควบคุม. ค่า# [<ผู้ใช้อลิซ> <ผมบ๊อบผู้ใช้> <ผู้ใช้แครอล>] ผล ควบคุม. cleaned_value # ["อลิซ", "บ๊อบ", "แครอล"] จบสิ้น         
     
  
โปรดทราบว่า#cleanวิธีการนี้จะยกเลิกบล็อกตัวล้างก่อนหน้าหากคุณเรียกใช้อีกครั้ง หากคุณจำเป็นต้องเข้าถึงบล็อกตัวทำความสะอาดที่กำหนดค่าไว้ในปัจจุบันด้วยเหตุผลบางประการScientist::Experiment#cleanerจะคืนค่าบล็อกนั้นโดยไม่ต้องกังวลใจอีกต่อไป (สิ่งนี้อาจไม่เกิดขึ้นในการใช้งานปกติ แต่มีประโยชน์หากคุณกำลังเขียน เช่น ตัวดำเนินการทดลองที่กำหนดเองซึ่งมีตัวทำความสะอาดเริ่มต้น)

ละเว้นไม่ตรงกัน
ในช่วงเริ่มต้นของการทดสอบ เป็นไปได้ว่าโค้ดบางส่วนของคุณมักจะสร้างความไม่ตรงกันด้วยเหตุผลที่คุณทราบและเข้าใจ แต่ยังไม่ได้แก้ไข แทนที่จะแสดงกรณีที่ทราบกันดีอยู่แล้วว่าไม่ตรงกันในเมตริกหรือการวิเคราะห์ของคุณ คุณสามารถบอกการทดสอบว่าจะเพิกเฉยต่อค่าที่ไม่ตรงกันโดยใช้ignoreวิธีการนี้หรือไม่ คุณอาจรวมมากกว่าหนึ่งบล็อกหากจำเป็น:

def  ผู้ดูแลระบบ? ( ผู้ใช้) 
  วิทยาศาสตร์ "อนุญาตวิดเจ็ต"  ทำ | อี |
    อี ใช้{ model . check_user ( ผู้ใช้) ผู้ดูแลระบบ? } จ. ลอง{ ผู้ใช้. สามารถ? ( :admin , model ) }   
        

    อี ละเว้น {  ผู้ใช้. พนักงาน?  }  # ผู้ใช้คือพนักงาน ผู้ดูแลระบบในระบบใหม่
    เสมอe . ละเลย ทำ | ควบคุม,  ผู้สมัคร |
      # ระบบใหม่ยังไม่รองรับผู้ใช้ที่ยังไม่ยืนยัน: 
      ควบคุม && ! ผู้สมัคร && ! ผู้ใช้งาน ยืนยัน_อีเมล? ปลายปลายปลาย
    
  
บล็อกการละเว้นจะถูกเรียกก็ต่อเมื่อค่าไม่ตรงกัน หากข้อสังเกตหนึ่งทำให้เกิดข้อยกเว้นและอีกข้อสังเกตหนึ่งไม่ถือว่าไม่ตรงกันเสมอ หากการสังเกตทั้งสองมีข้อยกเว้นต่างกัน ก็ถือว่าไม่ตรงกัน

การเปิด/ปิดการทดสอบ
บางครั้งคุณไม่ต้องการให้การทดสอบทำงาน พูดว่าปิดการใช้งาน codepath ใหม่สำหรับทุกคนที่ไม่ใช่พนักงาน คุณสามารถปิดการทดสอบโดยตั้งค่าการrun_ifบล็อก หากส่งคืนfalseการทดสอบจะส่งกลับค่าควบคุมเท่านั้น มิฉะนั้น จะเลื่อนไปตามenabled?วิธีที่กำหนดค่าของการทดสอบ

คลาส DashboardController 
  รวมถึง Scientist

  def  dashboard_items 
    science  "dashboard-items"  ทำ | อี |
      # ทำการทดลองนี้สำหรับพนักงาน
      เท่านั้นe . run_if  {  current_user . พนักงาน?  } 
      # ... 
  จบ
สิ้น
เร่งการทดลอง
ในฐานะนักวิทยาศาสตร์ คุณทราบดีว่าการปิดการทดลองของคุณเป็นสิ่งสำคัญเสมอ เพื่อไม่ให้เกิดอาละวาดและส่งผลให้ชาวบ้านมีโกยหน้าประตูบ้านคุณ ในการควบคุมว่าจะเปิดใช้งานการทดสอบหรือไม่ คุณต้องรวมenabled?วิธีการในScientist::Experimentการนำไปใช้ของคุณ

class  MyExperiment 
  รวม Scientist :: Experiment

  attr_accessor  :name ,  :percent_enabled

  def  เริ่มต้น( ชื่อ) 
    @name  =  ชื่อ
    @percent_enabled  =  100 
  end

   เปิดใช้งาน
    def ? percent_enabled > 0 && rand ( 100 ) < percent_enabled 
  end

  # ...

จบ
โค้ดนี้จะถูกเรียกใช้สำหรับทุกวิธีด้วยการทดสอบทุกครั้ง ดังนั้นโปรดระมัดระวังเกี่ยวกับประสิทธิภาพของโค้ด ตัวอย่างเช่น คุณสามารถจัดเก็บการทดสอบในฐานข้อมูล แต่รวมไว้ในแคชระดับต่างๆ เช่น memcache หรือ thread-locals ตามคำขอ

ประกาศผล
วิทยาศาสตร์จะดีอะไรหากคุณไม่สามารถเผยแพร่ผลงานของคุณได้

คุณต้องใช้publish(result)วิธีนี้และสามารถเผยแพร่ข้อมูลได้ตามที่คุณต้องการ ตัวอย่างเช่น ข้อมูลเวลาสามารถส่งข้อมูลไปยังกราไฟต์ และวางที่ไม่ตรงกันในคอลเล็กชันที่ต่อยอดใน redis เพื่อการดีบักในภายหลัง

publishวิธีการจะได้รับScientist::Resultตัวอย่างที่เกี่ยวข้องกับScientist::Observations:

class  MyExperiment 
  รวม Scientist :: Experiment

  # ...

  def  เผยแพร่( ผลลัพธ์)

    # เก็บระยะเวลาสำหรับค่าควบคุม$
    statsd ระยะเวลา "วิทยาศาสตร์. # { ชื่อ} .control" ,  ผล ควบคุม. ระยะเวลา# สำหรับผู้สมัคร (เฉพาะคนแรก ดูที่ "ฝ่าฝืนกฎ" ด้านล่าง 
    $statsd . timing "science. #{ name } .candidate" , ผล. ผู้สมัคร. ก่อน. ระยะเวลา
      

    # และจำนวนสำหรับการแข่งขัน / ไม่สนใจ / ไม่ตรงกัน: 
    ถ้า ผล ตรงกัน? 
      $statsd . เพิ่มขึ้น"วิทยาศาสตร์. # { ชื่อ} .matched" elsif ผล ละเลย? 
      $statsd . เพิ่มขึ้น"วิทยาศาสตร์. # { ชื่อ} .ignored" อื่น$
      statsd เพิ่ม"วิทยาศาสตร์#{ ชื่อ} .mismatched" # สุดท้าย เก็บไม่ตรงกันใน redis เพื่อให้สามารถดึงข้อมูลและตรวจสอบ# ในภายหลัง สำหรับการดีบักและการวิจัย store_mismatch_data ( 
      
     
      
      
      ผลลัพธ์) 
    สิ้นสุด
  สิ้นสุด

  def  store_mismatch_data ( ผล) 
    น้ำหนักบรรทุก =  { 
      : ชื่อ            =>  ชื่อ, 
      : บริบท         =>  บริบท, 
      การควบคุม         =>  observation_payload ( ผล. ควบคุม) , 
      : ผู้สมัคร       =>  observation_payload ( ผล. ผู้สมัคร. ครั้งแรก) , 
      : execution_order  =>  ผล ข้อสังเกต แผนที่( & :name ) }
    

    ที่สำคัญ =  "วิทยาศาสตร์. # { ชื่อ} .mismatch" $
    Redis lpush  คีย์,  น้ำหนักบรรทุก$
    Redis ปุ่มltrim  , 0 , 1000 end  
  

  def  observation_payload ( สังเกต) 
    ถ้า สังเกต ยก? { : ยกเว้น=> การสังเกต ข้อยกเว้น ระดับ, : ข้อความ=> การสังเกต ข้อยกเว้น ข้อความ, : การติดตามย้อนหลัง=> การสังเกต ข้อยกเว้น ติดตามย้อนหลัง} อื่น{ # ดูที่หัวข้อ "การรักษาความสะอาด" ด้านบน: ค่า=> การสังเกต cleaned_value } สิ้นสุดสิ้นสุดสิ้นสุด
      
          
            
          
      
    
      
        
          
      
    
  
การทดสอบ
เมื่อเรียกใช้ชุดทดสอบ คุณควรทราบว่าผลการทดสอบตรงกันเสมอ เพื่อช่วยในการทดสอบ Scientist ได้กำหนดraise_on_mismatchesแอตทริบิวต์ class เมื่อคุณรวมScientist::Experiment. ทำเช่นนี้เฉพาะในชุดทดสอบของคุณ!

หากต้องการเพิ่มเมื่อไม่ตรงกัน:

class  MyExperiment 
  include  Scientist :: Experiment 
  # ... การนำไปใช้
end

การทดลองของฉัน ยก_on_mismatches  =  จริง
นักวิทยาศาสตร์จะยกScientist::Experiment::MismatchErrorข้อยกเว้นหากมีการสังเกตไม่ตรงกัน

ข้อผิดพลาดที่ไม่ตรงกันที่กำหนดเอง
วิธีสั่งให้นักวิทยาศาสตร์แจ้งข้อผิดพลาดที่กำหนดเองแทนค่าเริ่มต้นScientist::Experiment::MismatchError:

คลาส CustomMismatchError < นักวิทยาศาสตร์ :: การทดลอง :: MismatchError 
  def  to_s 
    message  =  "มีไม่ตรงกัน! นี่คือความแตกต่าง:"

    diffs  =  ผล ผู้สมัคร. แผนที่ทำ | ผู้สมัคร |
      diff ใหม่( ผล. ควบคุม, ผู้สมัคร) สิ้นสุด เข้าร่วม( " \ n " )  
    

    " #{ ข้อความ} \n #{ diffs } " 
  end 
end
วิทยาศาสตร์ "อนุญาตวิดเจ็ต"  ทำ | อี |
  อี ใช้{ รายงาน. พบ( ID ) } อี ลอง{ ReportService . ใหม่. ดึงข้อมูล( id ) }   
     

  อี ยก_ด้วย CustomMismatchError 
สิ้นสุด
ซึ่งช่วยให้สามารถประมวลผลล่วงหน้าในข้อความแสดงข้อผิดพลาดที่ไม่ตรงกันได้

การจัดการข้อผิดพลาด
ในรหัสผู้สมัคร
นักวิทยาศาสตร์ช่วยเหลือและติดตามข้อยกเว้นทั้งหมดที่เกิดขึ้นใน a tryหรือuseblock รวมถึงบางส่วนที่การช่วยเหลืออาจทำให้เกิดพฤติกรรมที่ไม่คาดคิด (เช่นSystemExitหรือScriptError) หากต้องการกู้คืนชุดข้อยกเว้นที่เข้มงวดมากขึ้น ให้แก้ไขRESCUESรายการ:

# เริ่มต้นคือ [ยกเว้น] 
นักวิทยาศาสตร์ :: สังเกต :: ช่วยเหลือ แทนที่[ StandardError ] 
ในการเรียกกลับของนักวิทยาศาสตร์
หากมีข้อยกเว้นถูกยกขึ้นภายในใด ๆ ของผู้ช่วยเหลือภายในวิทยาศาสตร์เหมือนpublish, compareหรือcleanที่raisedวิธีการที่เรียกว่ามีชื่อสัญลักษณ์ของการดำเนินการภายในที่ล้มเหลวและข้อยกเว้นที่ถูกยกขึ้น พฤติกรรมเริ่มต้นScientist::Defaultคือเพียงแค่เพิ่มข้อยกเว้นใหม่ เนื่องจากการดำเนินการนี้หยุดการทดสอบทั้งหมด จึงเป็นความคิดที่ดีที่จะจัดการกับข้อผิดพลาดนี้และดำเนินการต่อเพื่อไม่ให้การทดสอบโดยรวมถูกยกเลิกทั้งหมด:

class  MyExperiment 
  รวม Scientist :: Experiment

  # ...

  def  ยก( การดำเนินงาน,  ข้อผิดพลาด) 
    InternalErrorTracker ติดตาม! "วิทยาศาสตร์ล้มเหลวใน#{ name } : #{ operation } " , error end end  
  