### PR TITLE
✨  Don't set default experiment for classes when `include`ing `Scientist::Experiment`

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -10,8 +10,13 @@ module Scientist::Experiment
   attr_accessor :raise_on_mismatches
 
   def self.included(base)
-    self.set_default(base) if base.instance_of?(Class)
+    set_default(base) if base.instance_of?(Class)
     base.extend RaiseOnMismatch
+  end
+
+  # Set this class as default scientist experiment when included.
+  def self.set_as_default_scientist_experiment(set_default_class)
+    set_default(Scientist::Default) unless set_default_class
   end
 
   # Instantiate a new experiment (using the class given to the .set_default method).

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -31,6 +31,19 @@ describe Scientist::Experiment do
     @ex = Fake.new
   end
 
+  it "does not set as default when default_scientist_experiment is passed as false" do
+    klass = Class.new do
+      include Scientist::Experiment
+
+      Scientist::Experiment.set_as_default_scientist_experiment(false)
+
+      def initialize(name)
+      end
+    end
+
+    assert_kind_of Scientist::Default, Scientist::Experiment.new("hello")
+  end
+
   it "sets the default on inclusion" do
     klass = Class.new do
       include Scientist::Experiment


### PR DESCRIPTION
Relates to https://github.com/github/scientist/issues/162. I'm happy to close if it's unnecessary!

Thoughts:
I found that making a class the default experiment a little aggressive and wondered if there was another way around this. It looks like in the code I could do something like [this](https://github.com/danielvdao/scientist/blob/7ed033f673a4a6f92bbf96dbf463764e44e560f3/test/scientist/experiment_test.rb#L6), but this seems not ideal for two reasons:
1. I would want to do `Scientist::Experiment.set_default(Scientist::Default)` to preserve backwards compatibility for current classes that `include Scientist`, but not `Scientist::Experiment`
2. Violates open-closed principle (e.g. if I wanted to do the above, then if it was decided that `Scientist::Default` was not the default class, then this could be a breaking change for gem users)

That said, I realized now that this might be my ignorance around the gem -- but it looks like running a scientist experiment class in isolation might not be "the right way to use the library" 😝  and I could've been wrong to begin with? Though I am wondering, if this allows for us to actually run multiple experiments at once 🤔  I attached a code snippet of what I was doing, and would love to hear thoughts!

I was doing something like the following:
```
class Foo
  include Scientist::Experiment
end
```

then:
```
      experiment = Foo.new.tap do |e|
        e.context(user_id: overdraft.user.id)
        e.try { limit_calculator.calculate_max_eligible_limit_new }
        e.use { limit_calculator.calculate_max_eligible_limit }
      end

      result = experiment.run
```