### PR TITLE
Add an optional `cohort` block to science experiments

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -290,6 +290,13 @@ module Scientist::Experiment
     try "control", &block
   end
 
+  # Define a block which will determine the cohort of this experiment
+  # when called. The block will be passed a `Scientist::Result` as its
+  # only argument and the cohort will be set on the result.
+  def cohort(&block)
+    @_scientist_determine_cohort = block
+  end
+
   # Whether or not to raise a mismatch error when a mismatch occurs.
   def raise_on_mismatches?
     if raise_on_mismatches.nil?
@@ -316,7 +323,7 @@ module Scientist::Experiment
     end
 
     control = observations.detect { |o| o.name == name }
-    Scientist::Result.new(self, observations, control)
+    Scientist::Result.new(self, observations, control, @_scientist_determine_cohort)
   end
 
   private

--- a/test/scientist/result_test.rb
+++ b/test/scientist/result_test.rb
@@ -98,6 +98,17 @@ describe Scientist::Result do
     assert_equal @experiment.name, result.experiment_name
   end
 
+  it "takes an optional callable to determine cohort" do
+    a = Scientist::Observation.new("a", @experiment) { 1 }
+    b = Scientist::Observation.new("b", @experiment) { 1 }
+
+    result = Scientist::Result.new @experiment, [a, b], a
+    assert_nil result.cohort
+
+    result = Scientist::Result.new @experiment, [a, b], a, ->(res) { "cohort-1" }
+    assert_equal "cohort-1", result.cohort
+  end
+
   it "has the context from an experiment" do
     @experiment.context :foo => :bar
     a = Scientist::Observation.new("a", @experiment) { 1 }


### PR DESCRIPTION
(This is the first of several improvements to scientist based on extractions from the GitHub monolith)

This adds the concept of a "cohort" to an experiment result, to enable and encourage bucketed result publishing. 

Many experiments operate on data with a very long tail, and the fat part of the distribution can completely wash out notable results in sub-groups with lower frequency.  For example, experiment results derived from the data of very large customers often look quite different than the much more common results from the small data, yet the latter might be so much more common as to make the former statistically invisible.  Even the use of percentile metrics can't overcome these effects since often the relevant percentiles are very high (above 99-percentile).

To address this issue, this PR adds an optional block to Science::Experiment which should return a "cohort" when called.  The cohort is passed the result of the experiment so it can determine the cohort from the context data, whether the result is a mismatch or any of the observation data.

The determined cohort value is available as `Scientist::Result#cohort` and is intended to be used by the user-defined publication mechanism.

Here's an example of how it might be used to segment the results of an experiment between "large" and "small" users:  

```ruby

science "widget-count" do |experiment|
  experiment.use { user.count_widgets }
  experiment.try { user.fast_count_widgets }
  experiment.cohort { |res| res.control.value > 100 ? "large" : "small" }
end
```