### PR TITLE
Re-enable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on: [push, pull_request]
+permissions:
+  actions: none
+  checks: write
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: write
+jobs:
+  build:
+    name: ruby-${{ matrix.ruby_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+          - "2.6"
+          - "2.7"
+          - "3.0"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require "rake/testtask"
+
+task default: "test"
+
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/test_helper.rb', 'test/**/*_test.rb']
+end

--- a/scientist.gemspec
+++ b/scientist.gemspec
@@ -18,6 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "minitest", "~> 5.8"
-  gem.add_development_dependency "coveralls", "~> 0.8"
   gem.add_development_dependency "rake"
 end

--- a/scientist.gemspec
+++ b/scientist.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "minitest", "~> 5.8"
   gem.add_development_dependency "coveralls", "~> 0.8"
+  gem.add_development_dependency "rake"
 end

--- a/script/test
+++ b/script/test
@@ -4,9 +4,4 @@
 set -e
 
 cd $(dirname "$0")/..
-  script/bootstrap && bundle exec ruby -I lib \
-    -e 'require "bundler/setup"' \
-    -e 'require "coveralls"; Coveralls.wear!{ add_filter ".bundle" }' \
-    -e 'require "minitest/autorun"' \
-    -e 'require "scientist"' \
-    -e '(ARGV.empty? ? Dir["test/**/*_test.rb"] : ARGV).each { |f| load f }' -- "$@"
+  script/bootstrap && bundle exec rake test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,4 @@
+require "minitest/autorun"
+
+$LOAD_PATH.unshift(File.expand_path(File.join(__dir__, "../lib")))
+require "scientist"


### PR DESCRIPTION
CI doesn't appear to be configured on this repo anymore, which makes it difficult to accept pull requests.  This PR:
 - Adds rake as a test runner with `test` as the default task.
 - Removes the coveralls gem since its configuration was lost.
 - Sets up Actions to run CI.  I've added a matrix that includes all supported MRI versions.

(see an example PR with this config [here](https://github.com/brasic/scientist/pull/1))