### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - "2.6"
           - "2.7"
           - "3.0"
+          - "3.1"
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Adds Ruby 3.1 to the CI matrix.  Runs green on my fork.