### PR TITLE
Fix method name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ class MyWidget
 end
 ```
 
-If either the control block or candidate block raises an error, Scientist compares the two observations' classes and messages using `==`. To override this behavior, use `compare_error` to define how to compare observed errors instead:
+If either the control block or candidate block raises an error, Scientist compares the two observations' classes and messages using `==`. To override this behavior, use `compare_errors` to define how to compare observed errors instead:
 
 ```ruby
 class MyWidget
@@ -132,7 +132,7 @@ class MyWidget
         candidate.message.start_with?("Invalid characters in input") 
       end
 
-      e.compare_error do |control, candidate|
+      e.compare_errors do |control, candidate|
         compare_error_message_and_class.call(control, candidate) ||
         compare_argument_errors.call(control, candidate)
       end


### PR DESCRIPTION
`compare_errors` was introduced in PR #77. Apparently, the latest renaming was forgotten to be applied to the README.

Thanks for this great library! 🤗 