### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR is add Ruby 3.2 to the CI matrix
Because Ruby 3.2.0 is now in general release, it makes sense to add Ruby 3.2 to the CI matrix.

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/