### PR TITLE
Fix example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ require "scientist"
 class MyWidget
   def allows?(user)
     experiment = Scientist::Default.new "widget-permissions"
-    experiment.use { model.check_user?(user).valid? } # old way
+    experiment.use { model.check_user(user).valid? } # old way
     experiment.try { user.can?(:read, model) } # new way
 
     experiment.run


### PR DESCRIPTION
- A method that has `?` suffix should return boolean, but this method return an object that respond to `valid?`.
- All other examples don't have `?`.
  - https://github.com/github/scientist/blob/8d9fd4ec676a0d3ba3be868b24415384108da2f0/README.md#L44
  - https://github.com/github/scientist/blob/8d9fd4ec676a0d3ba3be868b24415384108da2f0/README.md#L152
  - https://github.com/github/scientist/blob/8d9fd4ec676a0d3ba3be868b24415384108da2f0/README.md#L167
  - https://github.com/github/scientist/blob/8d9fd4ec676a0d3ba3be868b24415384108da2f0/README.md#L251
  - https://github.com/github/scientist/blob/8d9fd4ec676a0d3ba3be868b24415384108da2f0/README.md#L498
  - https://github.com/github/scientist/blob/8d9fd4ec676a0d3ba3be868b24415384108da2f0/README.md#L553