### PR TITLE
Add support for experiment after_run blocks

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -87,6 +87,16 @@ module Scientist::Experiment
     @_scientist_before_run = block
   end
 
+  # Define a block of code to run after an experiment completes, if the experiment
+  # is enabled.
+  #
+  # The block takes no arguments.
+  #
+  # Returns the configured block.
+  def after_run(&block)
+    @_scientist_after_run = block
+  end
+
   # A Hash of behavior blocks, keyed by String name. Register behavior blocks
   # with the `try` and `use` methods.
   def behaviors
@@ -229,6 +239,10 @@ module Scientist::Experiment
     end
 
     result = generate_result(name)
+
+    if @_scientist_after_run
+      @_scientist_after_run.call(result)
+    end
 
     begin
       publish(result)

--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -90,7 +90,7 @@ module Scientist::Experiment
   # Define a block of code to run after an experiment completes, if the experiment
   # is enabled.
   #
-  # The block takes no arguments.
+  # The block takes one argument, the Scientist::Result containing experiment results.
   #
   # Returns the configured block.
   def after_run(&block)

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -635,6 +635,37 @@ candidate:
     end
   end
 
+  describe "after run block" do
+    it "runs when an experiment is enabled" do
+      control_ok = candidate_ok = false
+      after_result = nil
+      @ex.after_run { |result| after_result = result }
+      @ex.use { control_ok = after_result.nil? }
+      @ex.try { candidate_ok = after_result.nil? }
+
+      @ex.run
+
+      assert after_result, "after_run should have run"
+      assert after_result.matched?, "after_run should be called with the result"
+      assert control_ok, "control should have run before after_run"
+      assert candidate_ok, "candidate should have run before after_run"
+    end
+
+    it "does not run when an experiment is disabled" do
+      after_result = nil
+
+      def @ex.enabled?
+        false
+      end
+      @ex.after_run { |result| after_result = result }
+      @ex.use { "value" }
+      @ex.try { "value" }
+      @ex.run
+
+      refute after_result, "after_run should not have run"
+    end
+  end
+
   describe "testing hooks for extending code" do
     it "allows a user to provide fabricated durations for testing purposes" do
       @ex.use { true }


### PR DESCRIPTION
This change allows an experiment to run custom behavior based on experiment results, eg

```ruby
science("my-experiment") do |e|
  e.use { control_method }
  e.try { candidate_method |

  # Slower candidates need further investigation
  e.after_run do |result|
    control_duration = result.control.duration
    candidate_duration = result.candidates.first.duration

    if candidate_duration - control_duration > 15
      Logger.debug("Slow experiment candidate #{context}")
    end
  end
end
```