### PR TITLE
Fix bug with marshalling experiments

### DIFF
--- a/lib/scientist/experiment.rb
+++ b/lib/scientist/experiment.rb
@@ -345,7 +345,7 @@ module Scientist::Experiment
     [@name, @result, @raise_on_mismatches]
   end
 
-  def marshal_load
+  def marshal_load(array)
     @name, @result, @raise_on_mismatches = array
   end
 end

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -513,7 +513,7 @@ describe Scientist::Experiment do
     end
 
     it "can be marshal loaded" do
-      assert_kind_of(Fake, Marshal.load(Marshal.dump(@ex))
+      assert_kind_of(Fake, Marshal.load(Marshal.dump(@ex)))
     end
 
     describe "#raise_on_mismatches?" do

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -512,6 +512,10 @@ describe Scientist::Experiment do
       assert_kind_of(String, Marshal.dump(mismatch))
     end
 
+    it "can be marshal loaded" do
+      assert_kind_of(Fake, Marshal.load(Marshal.dump(@ex))
+    end
+
     describe "#raise_on_mismatches?" do
       it "raises when there is a mismatch if the experiment instance's raise on mismatches is enabled" do
         Fake.raise_on_mismatches = false


### PR DESCRIPTION
Allows this to work:
```ruby
Marshal.load(Marshal.dump(Scientist::Default.new("foo")))
#=> ArgumentError: wrong number of arguments (given 1, expected 0)
#=> from /Users/ryan.buckley/.rvm/gems/ruby-2.7.8@envoy-web/gems/scientist-1.6.3/lib/scientist/experiment.rb:334:in `marshal_load'
```