### PR TITLE
CI against Ruby v3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Ruby 3.3 has been released, let's add Ruby v3.3 to CI matrix.