### PR TITLE
Report CPU Time alongside Wall Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,25 +550,7 @@ end
 
 #### Providing fake timing data
 
-If you're writing tests that depend on specific timing values, you can provide canned durations using the `fabricate_durations_for_testing_purposes` method. This can be done using either the old version (single value) or the new version (hash-based) to include both duration and cpu_time.
-
-##### Old version (Single Value)
-
-In the old version, you can provide a single value for the duration:
-
-```ruby
-science "absolutely-nothing-suspicious-happening-here" do |e|
-  e.use { ... } # "control"
-  e.try { ... } # "candidate"
-  e.fabricate_durations_for_testing_purposes( "control" => 1.0, "candidate" => 0.5 )
-end
-```
-
-`fabricate_durations_for_testing_purposes` takes a Hash of duration values, keyed by behavior names.  (By default, Scientist uses `"control"` and `"candidate"`, but if you override these as shown in [Trying more than one thing](#trying-more-than-one-thing) or [No control, just candidates](#no-control-just-candidates), use matching names here.)  If a name is not provided, the actual execution time will be reported instead.
-
-##### New version (Hash-based)
-
-Scientist will report these in `Scientist::Observation#duration` and `Scientist::Observation#cpu_time` instead of the actual execution times.
+If you're writing tests that depend on specific timing values, you can provide canned durations using the `fabricate_durations_for_testing_purposes` method, and Scientist will report these in `Scientist::Observation#duration` and `Scientist::Observation#cpu_time` instead of the actual execution times.
 
 ```ruby
 science "absolutely-nothing-suspicious-happening-here" do |e|

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ class MyWidget
       e.try { UserService.slug_from_login login }  # returns String instance or ArgumentError
 
       compare_error_message_and_class = -> (control, candidate) do
-        control.class == candidate.class && 
+        control.class == candidate.class &&
         control.message == candidate.message
       end
 
@@ -129,7 +129,7 @@ class MyWidget
         control.class == ArgumentError &&
         candidate.class == ArgumentError &&
         control.message.start_with?("Input has invalid characters") &&
-        candidate.message.start_with?("Invalid characters in input") 
+        candidate.message.start_with?("Invalid characters in input")
       end
 
       e.compare_errors do |control, candidate|
@@ -550,7 +550,25 @@ end
 
 #### Providing fake timing data
 
-If you're writing tests that depend on specific timing values, you can provide canned durations using the `fabricate_durations_for_testing_purposes` method, and Scientist will report these in `Scientist::Observation#duration` and `Scientist::Observation#cpu_time` instead of the actual execution times.
+If you're writing tests that depend on specific timing values, you can provide canned durations using the `fabricate_durations_for_testing_purposes` method. This can be done using either the old version (single value) or the new version (hash-based) to include both duration and cpu_time.
+
+##### Old version (Single Value)
+
+In the old version, you can provide a single value for the duration:
+
+```ruby
+science "absolutely-nothing-suspicious-happening-here" do |e|
+  e.use { ... } # "control"
+  e.try { ... } # "candidate"
+  e.fabricate_durations_for_testing_purposes( "control" => 1.0, "candidate" => 0.5 )
+end
+```
+
+`fabricate_durations_for_testing_purposes` takes a Hash of duration values, keyed by behavior names.  (By default, Scientist uses `"control"` and `"candidate"`, but if you override these as shown in [Trying more than one thing](#trying-more-than-one-thing) or [No control, just candidates](#no-control-just-candidates), use matching names here.)  If a name is not provided, the actual execution time will be reported instead.
+
+##### New version (Hash-based)
+
+Scientist will report these in `Scientist::Observation#duration` and `Scientist::Observation#cpu_time` instead of the actual execution times.
 
 ```ruby
 science "absolutely-nothing-suspicious-happening-here" do |e|

--- a/lib/scientist/observation.rb
+++ b/lib/scientist/observation.rb
@@ -35,9 +35,12 @@ class Scientist::Observation
       @exception = e
     end
 
-    if fabricated_duration
+    if fabricated_duration.is_a?(Hash)
       @duration = fabricated_duration["duration"]
       @cpu_time = fabricated_duration["cpu_time"]
+    elsif fabricated_duration
+      @duration = fabricated_duration
+      @cpu_time = 0.0 # setting a default value
     else
       end_wall_time, end_cpu_time = capture_times
       @duration = end_wall_time - start_wall_time

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -671,7 +671,20 @@ candidate:
   end
 
   describe "testing hooks for extending code" do
-    it "allows a user to provide fabricated durations for testing purposes" do
+    it "allows a user to provide fabricated durations for testing purposes (old version)" do
+      @ex.use { true }
+      @ex.try { true }
+      @ex.fabricate_durations_for_testing_purposes( "control" => 0.5, "candidate" => 1.0 )
+
+      @ex.run
+
+      cont = @ex.published_result.control
+      cand = @ex.published_result.candidates.first
+      assert_in_delta 0.5, cont.duration, 0.01
+      assert_in_delta 1.0, cand.duration, 0.01
+    end
+
+    it "allows a user to provide fabricated durations for testing purposes (new version)" do
       @ex.use { true }
       @ex.try { true }
       @ex.fabricate_durations_for_testing_purposes({
@@ -692,7 +705,20 @@ candidate:
       assert_equal 0.9, cand.cpu_time
     end
 
-    it "returns actual durations if fabricated ones are omitted for some blocks" do
+    it "returns actual durations if fabricated ones are omitted for some blocks (old version)" do
+      @ex.use { true }
+      @ex.try { sleep 0.1; true }
+      @ex.fabricate_durations_for_testing_purposes( "control" => 0.5 )
+
+      @ex.run
+
+      cont = @ex.published_result.control
+      cand = @ex.published_result.candidates.first
+      assert_in_delta 0.5, cont.duration, 0.01
+      assert_in_delta 0.1, cand.duration, 0.01
+    end
+
+    it "returns actual durations if fabricated ones are omitted for some blocks (new version)" do
       @ex.use { true }
       @ex.try do
         start_time = Time.now

--- a/test/scientist/experiment_test.rb
+++ b/test/scientist/experiment_test.rb
@@ -674,27 +674,47 @@ candidate:
     it "allows a user to provide fabricated durations for testing purposes" do
       @ex.use { true }
       @ex.try { true }
-      @ex.fabricate_durations_for_testing_purposes( "control" => 0.5, "candidate" => 1.0 )
-
+      @ex.fabricate_durations_for_testing_purposes({
+        "control" => { "duration" => 0.5, "cpu_time" => 0.4 },
+        "candidate" => { "duration" => 1.0, "cpu_time" => 0.9 }
+      })
       @ex.run
 
       cont = @ex.published_result.control
       cand = @ex.published_result.candidates.first
+
+      # Wall Time
       assert_in_delta 0.5, cont.duration, 0.01
       assert_in_delta 1.0, cand.duration, 0.01
+
+      # CPU Time
+      assert_equal 0.4, cont.cpu_time
+      assert_equal 0.9, cand.cpu_time
     end
 
     it "returns actual durations if fabricated ones are omitted for some blocks" do
       @ex.use { true }
-      @ex.try { sleep 0.1; true }
-      @ex.fabricate_durations_for_testing_purposes( "control" => 0.5 )
-
+      @ex.try do
+        start_time = Time.now
+        while Time.now - start_time < 0.1
+          # Perform some CPU-intensive work
+          (1..1000).each { |i| i * i }
+        end
+        true
+      end
+      @ex.fabricate_durations_for_testing_purposes({ "control" => { "duration" => 0.5, "cpu_time" => 0.4 }})
       @ex.run
 
       cont = @ex.published_result.control
       cand = @ex.published_result.candidates.first
+
+      # Fabricated durations
       assert_in_delta 0.5, cont.duration, 0.01
+      assert_in_delta 0.4, cont.cpu_time, 0.01
+
+      # Measured durations
       assert_in_delta 0.1, cand.duration, 0.01
+      assert_in_delta 0.1, cand.cpu_time, 0.01
     end
   end
 end

--- a/test/scientist/observation_test.rb
+++ b/test/scientist/observation_test.rb
@@ -6,13 +6,18 @@ describe Scientist::Observation do
 
   it "observes and records the execution of a block" do
     ob = Scientist::Observation.new("test", @experiment) do
-      sleep 0.1
+      start_time = Time.now
+      while Time.now - start_time < 0.1
+        # Perform some CPU-intensive work
+        (1..1000).each { |i| i * i }
+      end
       "ret"
     end
 
     assert_equal "ret", ob.value
     refute ob.raised?
     assert_in_delta 0.1, ob.duration, 0.01
+    assert_in_delta 0.1, ob.cpu_time, 0.01
   end
 
   it "stashes exceptions" do


### PR DESCRIPTION
We'd like to be able to quantify CPU time consumed while executing the 
candidate and control blocks during science experiments.

Changes include:
- Added `cpu_time` attribute to `Scientist::Observation`.
- Refactored initialization to capture both start/end times for wall
time and CPU time.
- Updated tests to include CPU work so we can verify we're
recording CPU time correctly.

This allows us to track cpu time more precisely when making improvements.